### PR TITLE
badges and waffle.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-json-fortran
+json-fortran [![GitHub release](https://img.shields.io/github/release/jacobwilliams/json-fortran.svg?style=plastic)](https://github.com/jacobwilliams/json-fortran/releases)
 ============
 
 A Fortran 2008 JSON API
+
+Status
+------
+[![GitHub issues](https://img.shields.io/github/issues/jacobwilliams/json-fortran.svg?style=plastic)](https://github.com/jacobwilliams/json-fortran/issues)
+[![Ready in backlog](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=Ready&title=Ready)](https://waffle.io/jacobwilliams/json-fortran)
+[![In Progress](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=In%20Progress&title=In%20Progress)](https://waffle.io/jacobwilliams/json-fortran)
 
 Brief Description
 ---------------


### PR DESCRIPTION
Do you have any interest in adding some badges (releases/versions, issues, and CI status) to the home page?

Also, waffle.io is a pretty neat and configurable tool to help automate the issue tracking and collaborative work on the issue backlog. It’s pretty easy to learn and straightforwards too.