### PR TITLE
Broken intel build.sh issue 53

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,8 +162,10 @@ enable_testing()
 find_program ( JSONLINT jsonlint )
 find_program ( DIFF     diff )
 set ( DATA_DIR ${CMAKE_BINARY_DIR}/files )
-configure_file ( ${CMAKE_SOURCE_DIR}/files/test1.json ${DATA_DIR}/test1.json COPYONLY )
-configure_file ( ${CMAKE_SOURCE_DIR}/files/test5.json ${DATA_DIR}/test5.json COPYONLY )
+configure_file ( ${CMAKE_SOURCE_DIR}/files/test1.json    ${DATA_DIR}/test1.json    COPYONLY )
+configure_file ( ${CMAKE_SOURCE_DIR}/files/test5.json    ${DATA_DIR}/test5.json    COPYONLY )
+configure_file ( ${CMAKE_SOURCE_DIR}/files/invalid.json  ${DATA_DIR}/invalid.json  COPYONLY )
+configure_file ( ${CMAKE_SOURCE_DIR}/files/invalid2.json ${DATA_DIR}/invalid2.json COPYONLY )
 
 # Validate input
 if ( JSONLINT )

--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,7 @@ then
 	# warning #7601: F2008 standard does not allow an internal procedure to be an actual argument procedure name. (R1214.4).
 	# In the context of F2008 this is an erroneous warning.
 	# See https://prd1idz.cps.intel.com/en-us/forums/topic/486629
-	FCOMPILERFLAGS= '-c -O2 -warn -stand f08 -diag-disable 7601 -traceback'
+	FCOMPILERFLAGS='-c -O2 -warn -stand f08 -diag-disable 7601 -traceback'
 	#FCOMPILERFLAGS='-c -O2 -warn -traceback -stand f08 -assume protect_parens -assume buffered_io -check all'
 
 else


### PR DESCRIPTION
This fixes #53. An extra space was in the Intel flags which was breaking the Intel build in a mysterious way when built with build.sh