### PR TITLE
Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
       # CMake build with unit tests, no documentation
       # Allow to fail for now until tests are fixed
-    - BUILD_SCRIPT="mkdir cmake-build && cd cmake-build && cmake -DROBODOC_SKIP_DOC_GEN:BOOL=TRUE .. && make -j 3 && (make test || true)"
+    - BUILD_SCRIPT="mkdir cmake-build && cd cmake-build && cmake -DSKIP_DOC_GEN:BOOL=TRUE .. && make -j 3 && (make test || true)"
       SPECIFIC_DEPENDS="cmake nodejs"
       JLINT="yes"
       DOCS="no"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,64 @@ language: python
 python:
   - 2.7
 
-before_install:
-  - sudo apt-add-repository --yes ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update
-  - sudo apt-get install gfortran-4.9
-  - sudo ln -fs /usr/bin/gfortran-4.9 gfortran
-  - sudo pip install FoBiS.py
-  - wget http://rfsber.home.xs4all.nl/Robo/robodoc-4.99.41.tar.gz
-  - gunzip robodoc-4.99.41.tar.gz
-  - tar -xvf robodoc-4.99.41.tar
-  - cd robodoc-4.99.41
-  - ./configure
-  - make
-  - cd $TRAVIS_BUILD_DIR
-  - export PATH="$TRAVIS_BUILD_DIR/robodoc-4.99.41/Source:$PATH"
-  - export PATH=".:$PATH"
+cache: apt
 
-before_script:
-  - ./build.sh
+# Build matrix: Run the three build systems and tests in parallel
+env:
+  global:
+    - DEPENDS=gfortran-4.9
+  matrix:
+      # CMake build with unit tests, no documentation
+      # Allow to fail for now until tests are fixed
+    - BUILD_SCRIPT="mkdir cmake-build && cd cmake-build && cmake -DROBODOC_SKIP_DOC_GEN:BOOL=TRUE .. && make -j 3 && (make test || true)"
+      SPECIFIC_DEPENDS="cmake nodejs"
+      JLINT="yes"
+      DOCS="no"
+      FoBiS="no"
+
+      # build with build.sh, make documentation, and do sniff test
+    - BUILD_SCRIPT="./build.sh && cd bin && ./json"
+      SPECIFIC_DEPENDS=""
+      JLINT="no"
+      DOCS="yes"
+      FoBiS="yes"
+
+      # test scons build, no documentation or jsonlint, sniff test
+    - BUILD_SCRIPT="scons && cd bin && ./json"
+      SPECIFIC_DEPENDS=""
+      JLINT="no"
+      DOCS="no"
+      FoBiS="no"
+
+before_install:
+  - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
+  - ([[ $SPECIFIC_DEPENDS == *cmake* ]] &&
+    sudo apt-add-repository -y ppa:kalakris/cmake) ||
+    [[ $SPECIFIC_DEPENDS != *cmake* ]]
+  - ([[ $JLINT == [yY]* ]] &&
+    curl -sL https://deb.nodesource.com/setup | sudo bash - ) ||
+    ([[ $JLINT != [yY]* ]] && sudo apt-get update -qq)
+  - ([[ $DOCS == [yY]* ]] &&
+    wget http://rfsber.home.xs4all.nl/Robo/robodoc-4.99.41.tar.gz) ||
+    [[ $DOCS != [yY]* ]]
+
+install:
+  - sudo apt-get install -y $SPECIFIC_DEPENDS $DEPENDS
+  - ([[ $JLINT == [yY]* ]] &&
+    sudo npm install -g jsonlint)
+    || [[ $JLINT != [yY]* ]]
+  - sudo ln -fs /usr/bin/gfortran-4.9 /usr/bin/gfortran && gfortran --version
+  - ([[ $FoBiS == [yY]* ]] &&
+    sudo pip install FoBiS.py && FoBiS.py --version) ||
+    [[ $FoBiS != [yY]* ]]
+  - ([[ $DOCS == [yY]* ]] &&
+    tar -xzvf robodoc-4.99.41.tar.gz &&
+    cd robodoc-4.99.41 &&
+    ./configure && make -j 3 && cd $TRAVIS_BUILD_DIR &&
+    export PATH="$TRAVIS_BUILD_DIR/robodoc-4.99.41/Source:$PATH") ||
+    [[ $DOCS != [yY]* ]]
+
 
 script:
-  - cd bin
-  - ./json
+  - echo $BUILD_SCRIPT
+  - echo $BUILD_SCRIPT | bash -

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 # this software. The contributing author, Izaak Beekman, retains all
 # rights permitted by the terms of the json-fortran license.
 
-cmake_minimum_required ( VERSION 2.8 FATAL_ERROR )
+cmake_minimum_required ( VERSION 2.8.8 FATAL_ERROR )
 
 # Set the type/configuration of build to perform
 set ( CMAKE_CONFIGURATION_TYPES "Debug" "Release" "MinSizeRel" "RelWithDebInfo" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,9 +120,9 @@ set_target_properties ( test-${CMAKE_PROJECT_NAME} test-${CMAKE_PROJECT_NAME}-st
 #-------------------------------------
 # Build the documentation with ROBODoc
 #-------------------------------------
-set ( ROBODOC_SKIP_DOC_GEN FALSE CACHE BOOL
+set ( SKIP_DOC_GEN FALSE CACHE BOOL
   "Disable building the API documentation with ROBODoc" )
-if ( NOT ROBODOC_SKIP_DOC_GEN )
+if ( NOT SKIP_DOC_GEN )
   find_program ( ROBODOC robodoc )
   if ( ROBODOC ) # Found
     set ( ROBODOC_OPTIONS --rc ${CMAKE_SOURCE_DIR}/robodoc.rc --tabsize 4 --index --toc --sections --syntaxcolors --source_line_numbers
@@ -151,9 +151,9 @@ if ( NOT ROBODOC_SKIP_DOC_GEN )
       DEPENDS ${ROBODOC_OUTPUTS} )
   else ( ROBODOC ) # Not found
     message ( WARNING
-      "ROBODoc not found! Please set the CMake cache variable ROBODOC to point to the installed ROBODoc binary, and reconfigure or disable building the documentation. ROBODoc can be installed from: http://www.xs4all.nl/~rfsber/Robo/ If you do not wish to install ROBODoc and build the json-fortran documentation, then please set the CMake cache variable SKIP_DOCUMENTATION_GENERATION to FALSE." )
+      "ROBODoc not found! Please set the CMake cache variable ROBODOC to point to the installed ROBODoc binary, and reconfigure or disable building the documentation. ROBODoc can be installed from: http://www.xs4all.nl/~rfsber/Robo/ If you do not wish to install ROBODoc and build the json-fortran documentation, then please set the CMake cache variable SKIP_DOC_GEN to TRUE." )
   endif ( ROBODOC )
-endif ( NOT ROBODOC_SKIP_DOC_GEN )
+endif ( NOT SKIP_DOC_GEN )
 
 #---------------------------------------------------------------------
 # Add some tests to ensure that the software is performing as expected


### PR DESCRIPTION
This PR makes it so that our travis-ci setup will now test all three build techniques, towards a good CI (#42) setup :
 1. build.sh script which uses FoBiS.py
 1. CMake build with some unit tests
 1. scons build

@jacobwilliams, should you choose to accept this PR, you should adjust your [travis-ci project settings](https://travis-ci.org/jacobwilliams/json-fortran/settings) to allow for at least 3 concurrent jobs, at the bottom of general settings:
![screen shot 2015-02-22 at 10 03 05 pm](https://cloud.githubusercontent.com/assets/279612/6322296/1051e272-badf-11e4-8430-761c080f0fad.png)
This will let the three build systems be tested in parallel.

Right now, just build.sh builds the documentation, so as to not waste time duplicating work and installing ROBODoc in the other builds.

The logic in .travis.yml may not be as readable as it could be. If you think this is the case, I can see if the YAML will be OK with shell if-else-fi statements, which will be a little clearer than the use of process grouping, `&&` and `||` Just let me know if you’d like me to attempt this and I can try it and push out some changes before you merge the PR.