### PR TITLE
Auto deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache: apt
 # Build matrix: Run the three build systems and tests in parallel
 env:
   global:
-    - DEPENDS=gfortran-4.9
+    - DEPENDS="gfortran-4.9"
   matrix:
       # CMake build with unit tests, no documentation
       # Allow to fail for now until tests are fixed
@@ -33,34 +33,25 @@ env:
       FoBiS="no"
 
 before_install:
+  - if [[ $DOCS == [yY]* ]]; then export DEPENDS="$DEPENDS exuberant-ctags"; fi
   - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
-  - ([[ $SPECIFIC_DEPENDS == *cmake* ]] &&
-    sudo apt-add-repository -y ppa:kalakris/cmake) ||
-    [[ $SPECIFIC_DEPENDS != *cmake* ]]
-  - ([[ $JLINT == [yY]* ]] &&
-    curl -sL https://deb.nodesource.com/setup | sudo bash - ) ||
-    ([[ $JLINT != [yY]* ]] && sudo apt-get update -qq)
-  - ([[ $DOCS == [yY]* ]] &&
-    wget http://rfsber.home.xs4all.nl/Robo/robodoc-4.99.41.tar.gz) ||
-    [[ $DOCS != [yY]* ]]
+  - if [[ $SPECIFIC_DEPENDS == *cmake* ]]; then sudo apt-add-repository -y ppa:kalakris/cmake; fi
+  - if [[ $JLINT == [yY]* ]]; then curl -sL https://deb.nodesource.com/setup | sudo bash -; else sudo apt-get update -qq; fi
+  - if [[ $DOCS == [yY]* ]]; then wget http://launchpadlibrarian.net/70968359/robodoc_4.99.41-1_amd64.deb; fi
 
 install:
   - sudo apt-get install -y $SPECIFIC_DEPENDS $DEPENDS
-  - ([[ $JLINT == [yY]* ]] &&
-    sudo npm install -g jsonlint)
-    || [[ $JLINT != [yY]* ]]
+  - if [[ $JLINT == [yY]* ]]; then sudo npm install -g jsonlint; fi
   - sudo ln -fs /usr/bin/gfortran-4.9 /usr/bin/gfortran && gfortran --version
-  - ([[ $FoBiS == [yY]* ]] &&
-    sudo pip install FoBiS.py && FoBiS.py --version) ||
-    [[ $FoBiS != [yY]* ]]
-  - ([[ $DOCS == [yY]* ]] &&
-    tar -xzvf robodoc-4.99.41.tar.gz &&
-    cd robodoc-4.99.41 &&
-    ./configure && make -j 3 && cd $TRAVIS_BUILD_DIR &&
-    export PATH="$TRAVIS_BUILD_DIR/robodoc-4.99.41/Source:$PATH") ||
-    [[ $DOCS != [yY]* ]]
-
+  - if [[ $FoBiS == [yY]* ]]; then sudo -H pip install FoBiS.py && FoBiS.py --version; fi
+  - if [[ $DOCS == [yY]* ]]; then sudo dpkg -i robodoc_4.99.41-1_amd64.deb && robodoc --version; fi
 
 script:
   - echo $BUILD_SCRIPT
   - echo $BUILD_SCRIPT | bash -
+
+after_success:
+  - cd $TRAVIS_BUILD_DIR
+  - git config --global user.name "TRAVIS-CI-for-$(git --no-pager show -s --format='%cn' $TRAVIS_COMMIT)"
+  - git config --global user.email "$(git --no-pager show -s --format='%ce' $TRAVIS_COMMIT)"
+  - ./deploy.sh #handles updating documentation for master branch as well as tags

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-json-fortran [![GitHub release](https://img.shields.io/github/release/jacobwilliams/json-fortran.svg?style=plastic)](https://github.com/jacobwilliams/json-fortran/releases)
+json-fortran [![GitHub release](https://img.shields.io/github/release/jacobwilliams/json-fortran.svg?style=plastic)](https://github.com/jacobwilliams/json-fortran/releases/latest)
 ============
 
 A Fortran 2008 JSON API
@@ -21,7 +21,7 @@ modern Fortran.  The source code is a single Fortran module file ([json_module.f
 Download [![GitHub release](https://img.shields.io/github/release/jacobwilliams/json-fortran.svg?style=plastic)](https://github.com/jacobwilliams/json-fortran/releases)
 --------------------
 
-Download the official versioned releases [here](https://github.com/jacobwilliams/json-fortran/releases).  Or, get the latest development code from the master branch [here](https://github.com/jacobwilliams/json-fortran.git).
+Download the official versioned releases [here](https://github.com/jacobwilliams/json-fortran/releases/latest).  Or, get the latest development code from the master branch [here](https://github.com/jacobwilliams/json-fortran.git).
 
 Building the library
 --------------------

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,7 @@
 #
 
 # Set to 1 to use ifort, otherwise use gfortran
+set -e
 use_ifort=0
 
 PROJECTNAME='jsonfortran'       # project name for robodoc (example: jsonfortran_2.0.0)

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Script to deploy documentation after successfull build of master branch or tag
+# If running under travis-ci this will automatically deploy updates to the master branch's
+# documentation on build events for the master branch, and will add/update documentation for
+# any new/updated tags that are pushed.
+# The script may also be used to manually deploy the current branch's documentation,
+# although for branch's other than master, index.html will likely need to be manually
+# edited to add an entry for the current branch. Also, this may be inadvisable, since the
+# the documentation can be published before the branch's code is published. Use it to add
+# new branch's development documentation, preferably immediately after pushing that branch
+# to github.
+set -ev # Echo what we're doing and fail on any errors
+if [ ! "$TRAVIS" ]; then #not on travis, try a sane deploy of current branch's documentation
+    if [ "$(ls -A ./documentation)" ]; then #not empty
+	REVISION="$(git rev-parse HEAD)"
+	BRANCH="$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')"
+	git clone --branch=gh-pages git@github.com:jacobwilliams/json-fortran.git gh-pages
+	cd gh-pages
+        [ -e "$BRANCH" ] && rm -r "$BRANCH" # wipe out old docs if they exist
+        mkdir "$BRANCH"
+        for f in ../documentation/*.*; do # add branch info to header and clean line endings
+	    sed '/[^#]robo_top_of_doc/ s;jsonfortran</a>;jsonfortran '"$BRANCH"'</a>;' $f | sed 's/ *$//' > "$BRANCH/${f##*/}"
+        done
+        git add "$BRANCH"
+        git commit -m "Development documentation for $BRANCH updated for commit $REVISION"
+	if egrep "\<${BRANCH}\>" index.html >/dev/null 2>&1 ; then
+	    echo "It appears that index.html knows about branch $BRANCH and likely does not require updating."
+	    git push origin gh-pages # assumes write access to jacobwilliams/json-fortran...
+	                             # only true for @jacobwilliams
+	else
+	    echo "index.html must be manually edited to add link to branch $BRANCH, then commit the changes and push manually."
+	fi
+    fi
+else #running under travis
+    if $TRAVIS_SECURE_ENV_VARS ; then
+	# only try to update master's development documentation
+	if [ "$TRAVIS_BRANCH" = "master" ] && [ "$(ls -A $TRAVIS_BUILD_DIR/documentation)" ] ; then #not empty
+            git clone --branch=gh-pages https://${GH_TOKEN}@github.com/$TRAVIS_REPO_SLUG gh-pages
+            cd gh-pages
+            [ -e master ] && rm -r master # wipe out docs if they exist
+            mkdir master
+            for f in ../documentation/*.*; do # add branch info to header and clean line endings
+		sed '/[^#]robo_top_of_doc/ s;jsonfortran</a>;jsonfortran master</a>;' $f | sed 's/ *$//' > master/${f##*/}
+            done
+            git add master
+            git commit -m "Development documentation updated by travis job $TRAVIS_JOB_NUMBER for commits $TRAVIS_COMMIT_RANGE"
+            git push origin gh-pages
+	fi
+	# If publishing a new/updated tag, deploy it's documentation
+	if [ "$TRAVIS_TAG" ] && [ "$(ls -A $TRAVIS_BUILD_DIR/documentation)" ] ; then #not empty
+	    git clone --branch=gh-pages https://${GH_TOKEN}@github.com/$TRAVIS_REPO_SLUG gh-pages
+	    cd gh-pages
+	    [ -e "$TRAVIS_TAG" ] && rm -r "$TRAVIS_TAG" # wipe out existing docs for tag if they exist
+	    mkdir "$TRAVIS_TAG"
+	    # Add an entry in index.html for the new tag, assume none exists
+	    awk '/<!--Next stable release goes here-->/{print "<a href=\"./'"$TRAVIS_TAG"'/masterindex.html\" class=\"indexitem\" >'"$TRAVIS_TAG"'</a>"}1' index.html > index2.html && mv index2.html index.html
+	    for f in ../documentation/*.*; do # add tag info to headers and clean line endings
+		sed '/[^#]robo_top_of_doc/ s;jsonfortran</a>;jsonfortran '"$TRAVIS_TAG"'</a>;' $f | sed 's/ *$//' > "$TRAVIS_TAG/${f##*/}"
+	    done
+	    git add "$TRAVIS_TAG" index.html # don't forget to add the top level index!
+	    git commit -m "Tag/release documentation updated by travis job $TRAVIS_JOB_NUMBER for tag $TRAVIS_TAG $TRAVIS_COMMIT"
+	    git push origin gh-pages
+	fi
+    fi
+fi


### PR DESCRIPTION
This adds some functionality discussed in #42.

Before you, @jacobwilliams, can use this, you need to add a secure environment variable to your travis-ci settings for json-fortran that contains a GitHub token with push access to json-fortran. The environment variable containing the token must be called `GH_TOKEN`. 
 1. To make a new token, on GitHub.com click the settings icon in the upper right corner —> Applications —> Generate New Token. (It only needs the public_repo access enabled.) Generate the new token then copy the token to your clipboard so you can paste it into travis-ci settings.
 1. On travis-ci.org click on the upper right hand Settings button for the repository: Settings —> Settings —> Environment Variables —> Add New Variable and call it `GH_TOKEN`, paste in the token value and add it. **DO NOT** change the toggle on the right hand side to on, if you do so you will expose your token to the world, giving anyone who finds it push access to your public GitHub repositories.

Here are some screen shots to help explain:

Make the token on GH:
![Making the GH token](https://cloud.githubusercontent.com/assets/279612/6353257/45ad2110-bc16-11e4-90fe-5848456fcf9f.png)

Adding the secure `GH_TOKEN` on travis-ci.org:
![Adding secure travis-ci token to environment](https://cloud.githubusercontent.com/assets/279612/6353332/b3533916-bc16-11e4-87a2-8adda82fab0d.png)

The `deploy.sh` script will do 1 of 3 things:
 1. If run manually, it assumes that there will be write access to jacobwilliams/json-fortran, (i.e., that you are @jacobwilliams) and will deploy the documentation for the current branch, if the documentation has been built under the folder `<branch_name>`. If this is `master` or if `<branch_name>` has previously been added to `index.html` it will completely publish the documentation, including the push to gh-pages. If `<branch_name>` is not linked to from `index.html` it will print a message suggesting that it be added, and stop short of the push, to allow manual intervention.
 1. If the master branch is pushed out to GitHub, and travis-ci builds documentation, the new documentation will be deployed to the `master` folder of the `gh-pages` branch. `index.html` doesn’t need any updating since it already contains a link to this.
 1. If a new tag is pushed out to GitHub, and travis-ci builds documentation for it, it will create or replace a directory with the name of the tag, and ensure that index.html is updated to contain a link to the new tag.

The `deploy.sh` script will **NOT**:
 1. publish changes when testing pull requests, only commits to jacobwilliams/json-fortran will cause deployments to jacobwilliams/json-fortran
 1. be able to publish changes to jacobwilliams/json-fortran/gh-pages from other people pushing changes in their own forks. Instead, it will attempt to publish to **THEIR** gh-pages branch of their forks. (But unless they update the `README.md` etc. those links will still point to https://jacobwilliams.github.io/json-fortran)

I’ve spent a lot of time checking my work, so I really hope this is useful, and that I’m as clever as I think I am. If you take a look at https://zbeekman.github.io/json-fortran you can see some of my testing with tags and master. If you accept this PR, I’m going to wipe out my gh-pages branch and then repopulate it with the upstream (@jacobwilliams’) branch. Let me know if you run into any issues.