### PR TITLE
Stops PRs by @jacobwilliams from deploying master docs

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -34,7 +34,7 @@ if [ ! "$TRAVIS" ]; then #not on travis, try a sane deploy of current branch's d
 else #running under travis
     if $TRAVIS_SECURE_ENV_VARS ; then
 	# only try to update master's development documentation
-	if [ "$TRAVIS_BRANCH" = "master" ] && [ "$(ls -A $TRAVIS_BUILD_DIR/documentation)" ] ; then #not empty
+	if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$(ls -A $TRAVIS_BUILD_DIR/documentation)" ] ; then #not empty
             git clone --branch=gh-pages https://${GH_TOKEN}@github.com/$TRAVIS_REPO_SLUG gh-pages
             cd gh-pages
             [ -e master ] && rm -r master # wipe out docs if they exist


### PR DESCRIPTION
This fixes an issue raised in the discussion of PR #59 whereby submitting PRs by @jacobwilliams against the master branch are causing the documentation to be deployed as the master documentation. (This shouldn’t happen until the PR is actually merged!)

I haven’t tested this, but it’s a very simple fix, so it *should* :pray: work