### PR TITLE
Added coveralls support for json_module.f90

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,26 +8,26 @@ cache: apt
 # Build matrix: Run the three build systems and tests in parallel
 env:
   global:
-    - DEPENDS="gfortran-4.9 binutils"
+    - DEPENDS="gfortran-4.9"
     - CHECK_README_PROGS="yes"
   matrix:
-      # CMake build with unit tests, no documentation
+      # CMake build with unit tests, no documentation, no coverage analysis
       # Allow to fail for now until tests are fixed
-    - BUILD_SCRIPT="mkdir cmake-build && cd cmake-build && cmake -DENABLE_CODE_COVERAGE:BOOL=TRUE -DSKIP_DOC_GEN:BOOL=TRUE .. && make -j 4 && make test"
+    - BUILD_SCRIPT="mkdir cmake-build && cd cmake-build && cmake -DSKIP_DOC_GEN:BOOL=TRUE .. && make -j 4 && make test"
       SPECIFIC_DEPENDS="cmake nodejs"
       JLINT="yes"
       DOCS="no"
       FoBiS="no"
 
-      # build with build.sh, make documentation, and do sniff test
+      # build with build.sh, make documentation, run unit tests and perform coverage analysis
     - BUILD_SCRIPT="./build.sh"
-      SPECIFIC_DEPENDS=""
+      SPECIFIC_DEPENDS="binutils"
       JLINT="no"
       DOCS="yes"
       FoBiS="yes"
       CODE_COVERAGE="yes"
 
-      # test scons build, no documentation or jsonlint, sniff test
+      # test scons build, no documentation or jsonlint, run unit tests
     - BUILD_SCRIPT="scons && scons test"
       SPECIFIC_DEPENDS=""
       JLINT="no"
@@ -35,6 +35,7 @@ env:
       FoBiS="no"
 
 before_install:
+  - ulimit -s unlimited
   - if [[ $CHECK_README_PROGS == [yY]* ]]; then wget http://people.sc.fsu.edu/~jburkardt/f_src/f90split/f90split.f90; fi
   - if [[ $DOCS == [yY]* ]]; then export DEPENDS="$DEPENDS exuberant-ctags"; fi
   - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
@@ -46,7 +47,9 @@ install:
   - sudo apt-get install -y $SPECIFIC_DEPENDS $DEPENDS
   - if [[ $JLINT == [yY]* ]]; then sudo npm install -g jsonlint; fi
   - sudo ln -fs /usr/bin/gfortran-4.9 /usr/bin/gfortran && gfortran --version
-  - if [[ $FoBiS == [yY]* ]]; then sudo -H pip install FoBiS.py==1.5.5 && FoBiS.py --version; fi
+  - sudo ln -fs /usr/bin/gcov-4.9 /usr/bin/gcov && gcov --version
+  - if [[ $FoBiS == [yY]* ]]; then sudo -H pip install FoBiS.py && FoBiS.py --version; fi
+  - if [[ $CODE_COVERAGE == [yY]* ]]; then sudo -H pip install cpp-coveralls; fi
   - if [[ $DOCS == [yY]* ]]; then sudo dpkg -i robodoc_4.99.41-1_amd64.deb && robodoc --version; fi
   - if [[ $CHECK_README_PROGS == [yY]* ]]; then gfortran -o f90split f90split.f90 && ./f90split README.md && shopt -s extglob && for f in !(README|CONTRIBUTING).md; do mv $f src/tests/jf_test_${f%.md}.f90; done; rm f90split.f90 f90split; fi
 
@@ -56,6 +59,7 @@ script:
 
 after_success:
   - cd $TRAVIS_BUILD_DIR
+  - if [[ $CODE_COVERAGE == [yY]* ]]; then gcov -o lib/ src/json_module.f90 && coveralls -n -b . ; fi
   - git config --global user.name "TRAVIS-CI-for-$(git --no-pager show -s --format='%cn' $TRAVIS_COMMIT)"
   - git config --global user.email "$(git --no-pager show -s --format='%ce' $TRAVIS_COMMIT)"
   - ./deploy.sh #handles updating documentation for master branch as well as tags

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Fortran 2008 JSON API
 Status
 ------
 [![Build Status](https://img.shields.io/travis/jacobwilliams/json-fortran/master.svg?style=plastic)](https://travis-ci.org/jacobwilliams/json-fortran)
+[![Coveralls branch](https://img.shields.io/coveralls/jacobwilliams/json-fortran/master.svg?style=plastic)](https://coveralls.io/r/jacobwilliams/json-fortran) <br/>
 [![GitHub issues](https://img.shields.io/github/issues/jacobwilliams/json-fortran.png?style=plastic)](https://github.com/jacobwilliams/json-fortran/issues)
 [![Blocked by Vendor Bug](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=vendor%20bug&title=Blocked%20by%20Vendor%20Bug)](https://waffle.io/jacobwilliams/json-fortran)
 [![Ready in backlog](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=Ready&title=Ready)](https://github.com/jacobwilliams/json-fortran/#contributing-)
@@ -102,8 +103,11 @@ for more examples. The source files may be found in `src/tests/`.
         ! extract data from the file
         ! [found can be used to check if the data was really there]
         call json%get('version.major', i, found)
+        if ( .not. found ) stop 1
         call json%get('version.minor', j, found)
+        if ( .not. found ) stop 1
         call json%get('data(1).number', k, found)
+        if ( .not. found ) stop 1
 
         ! clean up
         call json%destroy()
@@ -155,7 +159,6 @@ of `json_value` pointers.  For more examples see unit tests 2, 4 and 7 in `src/t
         use json_module
 
         type(json_value),pointer :: p, inp
-        logical :: found
 
         ! initialize the module
         call json_initialize()

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,6 @@ fi
 
 #build the stand-alone library:
 echo ""
-echo "${LFLAGS}"
 echo "Building library..."
 FoBiS.py build -compiler ${FCOMPILER} -cflags "${FCOMPILERFLAGS}" ${COVERAGE} -dbld ${LIBDIR} -s ${SRCDIR} -dmod ./ -dobj ./ -t ${MODCODE} -o ${LIBOUT} -mklib static -colors
 
@@ -87,7 +86,6 @@ echo ""
 if [[ $JF_SKIP_TESTS != [yY]* ]] ; then
     echo "Running tests..."
     cd "$BINDIR"
-    rm jf_test*.o jf_test*.mod || true
     OLD_IGNORES="$GLOBIGNORE"
     GLOBIGNORE='*.*'
     #

--- a/cmake/pickFortranCompilerFlags.cmake
+++ b/cmake/pickFortranCompilerFlags.cmake
@@ -26,7 +26,7 @@ if ( NOT Fortran_FLAGS_INIT )
     set ( ENABLE_CODE_COVERAGE FALSE CACHE BOOL
       "Compile with code coverage output enabled using gcov. May not work on Mac.")
     if ( ENABLE_CODE_COVERAGE )
-      set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} --coverage" )
+      set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fprofile-arcs -ftest-coverage" )
     endif ()
     if ( ENABLE_BACK_TRACE )
       set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fbacktrace" )


### PR DESCRIPTION
 - Fixes #63 : coverage info
 - skips coverage info about the tests, since the tests exist only to test json_module
 - currently only one build, the build.sh script will produce the coverage info and
   will update coveralls since doing it from multiple builds is redundant.

@jacobwilliams you will need to make a coveralls account and enable json-fortran repo.