### PR TITLE
Small fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ endif ()
 #---------------------------------------------
 # See if our compiler supports ISO 10646/UCS4
 #---------------------------------------------
-set ( ENABLE_UNICODE FLASE CACHE BOOL
+set ( ENABLE_UNICODE FALSE CACHE BOOL
   "Enable unicode/UCS4 support" )
 if ( ENABLE_UNICODE )
   try_run( UCS4_TEST_RUNS UCS4_TEST_COMPILES

--- a/SConstruct
+++ b/SConstruct
@@ -19,7 +19,7 @@ env = Environment()
 if env['FORTRAN'] == 'gfortran':
     env = Environment(F90FLAGS = '-O2 -fbacktrace -g -Wall -Wextra -Wno-maybe-uninitialized -Wno-unused-function -pedantic -std=f2008 -J',)
 elif env['FORTRAN'] == 'ifort':
-    env = Environment(F90FLAGS = '-O2 -warn -stand f08 -diag-disable 7601 -traceback -module lib',)
+    env = Environment(F90FLAGS = '-O2 -warn -stand f08 -diag-disable 7601 -diag-disable 5142 -traceback -module lib',)
 
 src = join('src','json_module.F90')
 ar  = join('lib','libjsonfortran'+env['LIBSUFFIX'])

--- a/build.sh
+++ b/build.sh
@@ -79,7 +79,7 @@ LIBOUT='libjsonfortran.a'       # name of json library
 # warning #7601: F2008 standard does not allow an internal procedure to be an actual argument procedure name. (R1214.4).
 # In the context of F2008 this is an erroneous warning.
 # See https://prd1idz.cps.intel.com/en-us/forums/topic/486629
-INTELCOMPILERFLAGS='-c -O2 -warn -stand f08 -diag-disable 7601 -diag-disable 4013 -traceback'
+INTELCOMPILERFLAGS='-c -O2 -warn -stand f08 -diag-disable 7601 -diag-disable 4013 -diag-disable 5142 -traceback'
 #INTELCOMPILERFLAGS='-c -O2 -warn -traceback -stand f08 -assume protect_parens -assume buffered_io -check all'
 
 GNUCOMPILERFLAGS='-c -O2 -fbacktrace -Wall -Wextra -Wno-maybe-uninitialized -Wno-unused-function -pedantic -std=f2008'

--- a/cmake/pickFortranCompilerFlags.cmake
+++ b/cmake/pickFortranCompilerFlags.cmake
@@ -17,7 +17,7 @@ if ( NOT Fortran_FLAGS_INIT )
       # warning #7601: F2008 standard does not allow an internal procedure to be an actual argument procedure
       # name. (R1214.4). In the context of F2008 this is an erroneous warning.
       # See https://prd1idz.cps.intel.com/en-us/forums/topic/486629
-      set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -warn -stand f08 -diag-disable 7601" )
+      set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -warn -stand f08 -diag-disable 7601 -diag-disable 5142" )
     endif ()
     if ( ENABLE_RUNTIME_CHECKS )
       set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -check all" )


### PR DESCRIPTION
 * Silence mysterious intel warning: 5142 "invalid use of $ character"
 * Typo in CMakeLists.txt fixed so that build defaults to non-unicode, like build.sh

Fixes #96 