### PR TITLE
Make check issue 103

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   matrix:
       # CMake build with unit tests, no documentation, no coverage analysis
       # Allow to fail for now until tests are fixed
-    - BUILD_SCRIPT="mkdir cmake-build && cd cmake-build && cmake -DSKIP_DOC_GEN:BOOL=TRUE -DENABLE_UNICODE:BOOL=TRUE .. && make -j 4 && make test"
+    - BUILD_SCRIPT="mkdir cmake-build && cd cmake-build && cmake -DSKIP_DOC_GEN:BOOL=TRUE -DENABLE_UNICODE:BOOL=TRUE .. && make -j 4 check"
       SPECIFIC_DEPENDS="cmake nodejs"
       JLINT="yes"
       DOCS="no"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,9 @@ set ( ENABLE_TESTS TRUE CACHE BOOL
 if ( ENABLE_TESTS )
   enable_testing()
 
+  # emulate GNU Autotools `make check`
+  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+
   find_program ( JSONLINT jsonlint )
   find_program ( DIFF     diff )
   file ( COPY "${CMAKE_SOURCE_DIR}/files"
@@ -235,8 +238,9 @@ if ( ENABLE_TESTS )
   set ( UNIT_TESTS '' )
   foreach ( UNIT_TEST ${JF_TEST_SRCS} )
     get_filename_component ( TEST ${UNIT_TEST} NAME_WE )
-    add_executable ( ${TEST} ${UNIT_TEST} )
+    add_executable ( ${TEST} EXCLUDE_FROM_ALL ${UNIT_TEST} )
     target_link_libraries ( ${TEST} ${LIB_NAME} )
+    add_dependencies ( check ${TEST} )
     set_target_properties ( ${TEST}
       PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,22 @@
 
 Looking to contribute something to [json-fortran](README.md)? **Here's how you can help.**
 
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
+**Table of Contents**
+
+  - [Key Branches](#key-branches)
+  - [Filing issues](#filing-issues)
+  - [Outstanding Work](#outstanding-work)
+  - [Pull Requests](#pull-requests)
+  - [Coding Standards](#coding-standards)
+
+<!-- markdown-toc end -->
+
 ## Key Branches
 
 - `master` is the latest, development version and all efforts should be made to keep it stable.
 
+[top](#contributing-to-json-fortran)
 ## Filing issues
 
 - Before filing a new [issue](https://github.com/jacobwilliams/json-fortran/issues), please perform a search to see if that issue has already been filed by someone else, and whether or not a solution exists. If you are experiencing the same issue as one that's already posted, please leave any additional comments and information under the existing issue. If your issue is related to a previous issue, but substantively different, file a new issue and include a mention of the related issue in text, using GitHub's `#<issue-number>` syntax.
@@ -16,10 +28,12 @@ Looking to contribute something to [json-fortran](README.md)? **Here's how you c
   1. If applicable, what compiler you used, and any non-standard options or configurations that were used.
   1. All steps required to reproduce the problem
 
+[top](#contributing-to-json-fortran)
 ## Outstanding Work
 
 - Take a look at the [issues](https://github.com/jacobwilliams/json-fortran/issues) to see if there is an issue you'd like to help address. [Issues](https://github.com/jacobwilliams/json-fortran/issues) with the [ready label](https://github.com/jacobwilliams/json-fortran/issues?q=is%3Aopen+is%3Aissue+label%3A%22ready%22) or in the [ready column on waffle.io](https://waffle.io/jacobwilliams/json-fortran) are issues that are ready to be dealt with. (i.e., They are not blocked by other dependencies and are higher priority.)
 
+[top](#contributing-to-json-fortran)
 ## Pull Requests
 
 - Try not to pollute your pull request with unintended changes--keep them simple and small
@@ -38,6 +52,7 @@ git rebase upstream
 - Pull requests are tested by our [travis-ci](https://travis-ci.org/jacobwilliams/json-fortran) continuous integration system, and any errors uncovered will need to be fixed before the pull request can be merged into master.
 - The json-fortran library and associated documentation is released under a BSD style [license](https://github.com/jacobwilliams/json-fortran/blob/master/LICENSE).  By submitting a pull request, you are agreeing to release your code under the same license.  Note that code with GPL or other "copyleft" style licenses will not be accepted.
 
+[top](#contributing-to-json-fortran)
 ## Coding Standards
 
 - Each commit should address a single logical change and code base transformation.
@@ -49,3 +64,5 @@ git rebase upstream
 - The coding style is modern free-form Fortran, consistent with the Fortran 2008 standard.  Note that the two supported compilers (ifort and gfortran) do not currently include the entire Fortran 2008 standard. Therefore, only those language features supported by Gfortran 4.9 and Intel 13.1.0 are currently allowed.  This also means that previous versions of these compilers are not supported, and major changes to the code to support earlier compilers (or Fortran 95) will not be accepted.  At some point in the future (when compiler support has improved), all Fortran 2008 features will be allowed.
 - All subroutines and functions *must* be properly documented.  This includes useful inline comments as well as comment blocks using the [ROBODoc](http://rfsber.home.xs4all.nl/Robo/manual.html) syntax.
 - For simplicity, json-fortran currently consists of one module file. It is not envisioned that it will ever need to expand to include multiple files (if it does, there would need to be a very good reason).
+
+[top](#contributing-to-json-fortran)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,13 +39,15 @@ Looking to contribute something to [json-fortran](README.md)? **Here's how you c
 - Try not to pollute your pull request with unintended changes--keep them simple and small
 - Pull requests should address one issue at a time, and each commit should be a set of self contained, related changes. If you forget something in a commit, please use `git rebase -i <ref>^` to amend and/or squash erroneous commits. Here `<ref>` is the reference to to oldest commit needing to be modified (SHA, or `HEAD~4`, etc.)
 - Each commit should compile, and ideally pass the tests. Very complicated new features or fixes, may have commits that don't pass tests, if otherwise the commit history would include far to many changes in any given commit. Use an interactive rebase to fix any of these issues, as described above.
-- Pull requests should always be based on the upstream master, jacobwilliams/json-fortran:master. Please `rebase` your branch on top of the latest upstream master. Assuming you've added the upstream remote by running something like:
+- Pull requests should always be based on the upstream master,
+jacobwilliams/json-fortran:master. Please `rebase` your branch on top
+of the latest upstream master. Assuming you are on your branch and you've added the upstream remote by running something like:
 ```
 git remote add upstream git://github.com/jacobwilliams/json-fortran.git
 ```
 You can accomplish this by running:
 ```
-git rebase upstream
+git rebase upstream/master
 ```
 - Create a branch in your fork with a descriptive name that also includes the [issue number](https://github.com/jacobwilliams/json-fortran/issues), if applicable. For example, after forking the repo, you can run something like `git checkout -b Unicode-support-issue-35` before starting work on [issue #35 : Unicode support](https://github.com/jacobwilliams/json-fortran/issues/35)
 - When you're content with your changes, your commits are clean, self contained, with concise descriptive messages, and your changes compile and pass the tests, submit a pull request. We will review your changes, and may ask for certain modifications to be made.

--- a/README.md
+++ b/README.md
@@ -6,20 +6,19 @@ A Fortran 2008 JSON API
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->
 **Table of Contents**
 
-- [json-fortran [![GitHub release](https://img.shields.io/github/release/jacobwilliams/json-fortran.svg?style=plastic)](https://github.com/jacobwilliams/json-fortran/releases/latest)](#json-fortran-github-releasehttpsimgshieldsiogithubreleasejacobwilliamsjson-fortransvgstyleplastichttpsgithubcomjacobwilliamsjson-fortranreleaseslatest)
-    - [Status](#status)
-    - [Brief description](#brief-description)
-    - [Download [![GitHub release](https://img.shields.io/github/release/jacobwilliams/json-fortran.svg?style=plastic)](https://github.com/jacobwilliams/json-fortran/releases)](#download-github-releasehttpsimgshieldsiogithubreleasejacobwilliamsjson-fortransvgstyleplastichttpsgithubcomjacobwilliamsjson-fortranreleases)
-    - [Building the library](#building-the-library)
-    - [Reading JSON from a file](#reading-json-from-a-file)
-    - [Reading JSON from a string](#reading-json-from-a-string)
-    - [Modifying variables in a JSON file](#modifying-variables-in-a-json-file)
-    - [Writing a JSON file](#writing-a-json-file)
-    - [Building a JSON file from scratch](#building-a-json-file-from-scratch)
-    - [Documentation](#documentation)
-    - [Contributing [![Ready in backlog](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=Ready&title=Ready)](CONTRIBUTING.md)](#contributing-ready-in-backloghttpsbadgewaffleiojacobwilliamsjson-fortranpnglabelreadytitlereadycontributingmd)
-    - [License](#license)
-    - [Miscellaneous](#miscellaneous)
+  - [Status](#status)
+  - [Brief description](#brief-description)
+  - [Download](#download-)
+  - [Building the library](#building-the-library)
+  - [Reading JSON from a file](#reading-json-from-a-file)
+  - [Reading JSON from a string](#reading-json-from-a-string)
+  - [Modifying variables in a JSON file](#modifying-variables-in-a-json-file)
+  - [Writing a JSON file](#writing-a-json-file)
+  - [Building a JSON file from scratch](#building-a-json-file-from-scratch)
+  - [Documentation](#documentation)
+  - [Contributing](#contributing-)
+  - [License](#license)
+  - [Miscellaneous](#miscellaneous)
 
 <!-- markdown-toc end -->
 
@@ -34,17 +33,20 @@ Status
 [![In Progress](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=In%20Progress&title=In%20Progress)](https://waffle.io/jacobwilliams/json-fortran)
 [![Needs Review](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=Needs%20Review&title=Needs%20Review)](https://waffle.io/jacobwilliams/json-fortran)
 
+[top](#json-fortran-)
 Brief description
 ---------------
 
 A user-friendly and object-oriented API for reading and writing JSON files, written in
 modern Fortran.  The source code is a single Fortran module file ([json_module.F90](https://github.com/jacobwilliams/json-fortran/blob/master/src/json_module.F90)).
 
+[top](#json-fortran-)
 Download [![GitHub release](https://img.shields.io/github/release/jacobwilliams/json-fortran.svg?style=plastic)](https://github.com/jacobwilliams/json-fortran/releases)
 --------------------
 
 Download the official versioned releases [here](https://github.com/jacobwilliams/json-fortran/releases/latest).  Or, get the latest development code from the master branch [here](https://github.com/jacobwilliams/json-fortran.git).
 
+[top](#json-fortran-)
 Building the library
 --------------------
 
@@ -86,7 +88,7 @@ cmake_minimum_required ( VERSION 2.8.8 FATAL_ERROR )
 enable_language ( Fortran )
 project ( jf_test NONE )
 
-find_package ( jsonfortran-${CMAKE_Fortran_COMPILER_ID} 4.1.0 REQUIRED )
+find_package ( jsonfortran-${CMAKE_Fortran_COMPILER_ID} 4.1.1 REQUIRED )
 include_directories ( "${jsonfortran_INCLUDE_DIRS}" )
 
 file ( GLOB JF_TEST_SRCS "src/tests/jf_test_*.f90" )
@@ -99,6 +101,7 @@ foreach ( UNIT_TEST ${JF_TEST_SRCS} )
 endforeach()
 ```
 
+[top](#json-fortran-)
 Reading JSON from a file
 ---------------
 
@@ -140,6 +143,7 @@ for more examples. The source files may be found in `src/tests/`.
     end program example1
 ```
 
+[top](#json-fortran-)
 Reading JSON from a string
 ---------------
 JSON can also be read directly from a character string like so:
@@ -159,6 +163,7 @@ After reading a JSON file, if you want to change the values of some of the varia
     call json%update('version.patch',0,found)  !change patch to 0
 ```
 
+[top](#json-fortran-)
 Writing a JSON file
 ---------------
 
@@ -169,6 +174,7 @@ To print the JSON file (either to a file or the console), the `print_file` metho
     call json%print_file(iunit)    !prints to the file connected to iunit
 ```
 
+[top](#json-fortran-)
 Building a JSON file from scratch
 ---------------
 
@@ -244,19 +250,23 @@ The code above produces the file:
 }
 ```
 
+[top](#json-fortran-)
 Documentation
 --------------
 
 The API documentation for the latest release version can be found [here](http://jacobwilliams.github.io/json-fortran).  The documentation can also be generated by processing the source files with [RoboDoc](http://rfsber.home.xs4all.nl/Robo/).  Note that both the shell script, CMake, and SCons will also generate these files automatically in the documentation folder, assuming you have RoboDoc installed.
 
+[top](#json-fortran-)
 Contributing [![Ready in backlog](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=Ready&title=Ready)](CONTRIBUTING.md)
 ------------
 Want to help?  Take a quick look at our [contributing guidelines](CONTRIBUTING.md) then claim something in [the "ready" column on our Waffle.io](https://waffle.io/jacobwilliams/json-fortran) and [Fork. Commit. Pull request.](https://help.github.com/articles/fork-a-repo).
 
+[top](#json-fortran-)
 License
 --------
 The json-fortran source code and related files and documentation are distributed under a permissive free software license (BSD-style).  See the [LICENSE](https://raw.githubusercontent.com/jacobwilliams/json-fortran/master/LICENSE) file for more details.
 
+[top](#json-fortran-)
 Miscellaneous
 ---------------
 
@@ -265,3 +275,5 @@ Miscellaneous
 * [json-fortran on Travis CI](https://travis-ci.org/jacobwilliams/json-fortran)
 * [json-fortran on Waffle.IO](https://waffle.io/jacobwilliams/json-fortran)
 * [json-fortran on Coveralls.IO](https://coveralls.io/r/jacobwilliams/json-fortran)
+
+[top](#json-fortran-)


### PR DESCRIPTION
Fixes #103 
 - Add `check` target via CMake, so that `make check` after running CMake will build *AND* run the tests. (by default CMake/CTest’s `make test` command does not create a dependency on building the executables needed to do the testing.)
 - Remove all test executables from the default `all` target which is run whenever `make` or `make all` is run
 - `make test` will still work, but only after all the tests have been build, and these must be built individually, or by running `make check`

The consequences of this are that:
 1. If you just want to build (or build and install) the library, you don’t have to wait until all the tests build
 2. If you want to build everything and run all the tests you can just type `make check`