### PR TITLE
Small FoBiS coverage fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,11 @@ install:
 
 script:
   - echo $BUILD_SCRIPT
-  - echo $BUILD_SCRIPT | bash -
+  - bash <<<$BUILD_SCRIPT
 
 after_success:
   - cd $TRAVIS_BUILD_DIR
-  - if [[ $CODE_COVERAGE == [yY]* ]]; then gcov -o lib/ src/json_module.F90 && bash <(curl -s https://codecov.io/bash) ; fi
+  - if [[ $CODE_COVERAGE == [yY]* ]]; then bash <(curl -s https://codecov.io/bash) ; fi
   - git config --global user.name "TRAVIS-CI-for-$(git --no-pager show -s --format='%cn' $TRAVIS_COMMIT)"
   - git config --global user.email "$(git --no-pager show -s --format='%ce' $TRAVIS_COMMIT)"
   - ./deploy.sh #handles updating documentation for master branch as well as tags

--- a/build.sh
+++ b/build.sh
@@ -237,6 +237,7 @@ fi
 if [[ $CODE_COVERAGE == [yY]* ]]; then
     echo "Trying to compile with code coverage instrumentation."
     COVERAGE="-coverage"
+    FCOMPILERFLAGS+=' -O0'
 fi
 
 if [[ $CODE_PROFILE == [yY]* ]]; then


### PR DESCRIPTION
Inaccurate coverage statistics are reported when optimization is used. Even with the `-coverage` flag to FoBiS.py, an optimization level of `-O2` has been used which causes inlining which in turn decreases the reported coverage. See https://github.com/szaghi/FoBiS/issues/60

Additionally the codecov.io bash script now recursively searches for `.gcno` files and runs gcov on each one it finds. This may cause the unit tests’ coverage to get added to the grand total. To fix this go to the projects codecov.io page and on the right hand side go to ‘Features’ ==> ‘Ignore Files’ and enter something like `src/tests` and hit submit. Now this should display the correct coverage for ONLY `src/json_module.F90`.

A happy side effect of this is that, using the codecov.io browser plugins coverage information will be shown for the tests on github which is useful info to have so that it is possible to easily see which lines of the tests are executed, without them contributing to the coverage totals.