### PR TITLE
fixes 85 allow output to 0 (stderr)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,15 @@ env:
     - DEPENDS="gfortran-4.9"
     - CHECK_README_PROGS="yes"
   matrix:
-      # CMake build with unit tests, no documentation, no coverage analysis
-      # Allow to fail for now until tests are fixed
-    - BUILD_SCRIPT="mkdir cmake-build && cd cmake-build && cmake -DSKIP_DOC_GEN:BOOL=TRUE -DENABLE_UNICODE:BOOL=TRUE .. && make -j 4 check"
+      # CMake build with unit tests, no documentation, with coverage analysis
+      # No unicode so that coverage combined with the build script will cover unicode
+      # and non-unicode code paths
+    - BUILD_SCRIPT="mkdir cmake-build && cd cmake-build && cmake -DSKIP_DOC_GEN:BOOL=TRUE -DCMAKE_BUILD_TYPE=COVERAGE .. && make -j 4 check"
       SPECIFIC_DEPENDS="cmake nodejs"
       JLINT="yes"
       DOCS="no"
       FoBiS="no"
+      CODE_COVERAGE="yes"
 
       # build with build.sh, make documentation, run unit tests and perform coverage analysis
     - BUILD_SCRIPT="./build.sh --coverage --enable-unicode"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,11 @@ cmake_minimum_required ( VERSION 2.8.8 FATAL_ERROR )
 set ( CMAKE_CONFIGURATION_TYPES "Debug" "Release" "MinSizeRel" "RelWithDebInfo" )
 set ( CMAKE_BUILD_TYPE "Release"
   CACHE STRING "Select which configuration to build." )
-set_property ( CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${CMAKE_CONFIGURATION_TYPES} )
 
 enable_language ( Fortran )
 include ( "cmake/pickFortranCompilerFlags.cmake" )
+
+set_property ( CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${CMAKE_CONFIGURATION_TYPES} )
 
 # Check for in-source builds and error out if found
 # Provides an advanced option to allow in source builds

--- a/cmake/pickFortranCompilerFlags.cmake
+++ b/cmake/pickFortranCompilerFlags.cmake
@@ -23,11 +23,10 @@ if ( NOT Fortran_FLAGS_INIT )
       set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -check all" )
     endif ()
   elseif ( "${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU" )
-    set ( ENABLE_CODE_COVERAGE FALSE CACHE BOOL
-      "Compile with code coverage output enabled using gcov. May not work on Mac.")
-    if ( ENABLE_CODE_COVERAGE )
-      set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fprofile-arcs -ftest-coverage" )
-    endif ()
+    # add a coverage build configuration
+    set ( CMAKE_CONFIGURATION_TYPES ${CMAKE_CONFIGURATION_TYPES} "Coverage" )
+    set ( CMAKE_Fortran_FLAGS_COVERAGE "-fprofile-arcs -ftest-coverage -O0" CACHE STRING
+      "Fortran compiler flags for coverage configuration" )
     if ( ENABLE_BACK_TRACE )
       set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fbacktrace" )
     endif ()

--- a/src/json_module.F90
+++ b/src/json_module.F90
@@ -1146,6 +1146,9 @@
     integer(IK),parameter :: chunk_size = 100  !allocate chunks of this size
     integer(IK) :: ipos = 1    !next character to read
 
+    !unit number to cause stuff to be output to strings rather than files
+    !See 9.5.6.12 in the F2003/08 standard
+    integer(IK),parameter :: unit2str = -1
     contains
 !*****************************************************************************************
 
@@ -1386,15 +1389,15 @@
     implicit none
 
     class(json_file),intent(inout)  :: me
-    integer(IK),intent(in)          :: iunit  !must be non-zero
+    integer(IK),intent(in)          :: iunit  !must not be -1
 
     integer(IK) :: i
     character(kind=CK,len=:),allocatable :: dummy
 
-    if (iunit/=0) then
+    if (iunit/=unit2str) then
         i = iunit
     else
-        call throw_exception('Error in json_file_print_1: iunit must be nonzero.')
+        call throw_exception('Error in json_file_print_1: iunit must not be -1.')
         return
     end if
 
@@ -4217,7 +4220,7 @@
     character(kind=CK,len=:),intent(out),allocatable :: str
 
     str = ''
-    call json_value_print(me, iunit=0, str=str, indent=1, colon=.true.)
+    call json_value_print(me, iunit=unit2str, str=str, indent=1, colon=.true.)
 
     end subroutine json_value_to_string
 !*****************************************************************************************
@@ -4232,7 +4235,7 @@
 !    Print the JSON structure to a file.
 !
 !  INPUT
-!    * iunit is the nonzero file unit (the file must already have been opened).
+!    * iunit is the file unit (the file must already have been opened, can't be -1).
 !
 !  AUTHOR
 !    Jacob Williams, 6/20/2014
@@ -4244,13 +4247,13 @@
     implicit none
 
     type(json_value),pointer,intent(in)  :: me
-    integer(IK),intent(in)               :: iunit    !must be non-zero
+    integer(IK),intent(in)               :: iunit    !must not be -1
     character(kind=CK,len=:),allocatable :: dummy
 
-    if (iunit/=0) then
+    if (iunit/=unit2str) then
         call json_value_print(me,iunit,str=dummy, indent=1, colon=.true.)
     else
-        call throw_exception('Error in json_print: iunit must be nonzero.')
+        call throw_exception('Error in json_print: iunit must not be -1.')
     end if
 
     end subroutine json_print_1
@@ -4321,7 +4324,7 @@
     logical(LK),intent(in),optional      :: need_comma        !if it needs a comma after it
     logical(LK),intent(in),optional      :: colon             !if the colon was just written
     character(kind=CK,len=:),intent(inout),allocatable :: str
-                                                      !if iunit==0, then the structure is
+                                                      !if iunit==unit2str (-1) then the structure is
                                                       ! printed to this string rather than
                                                       ! a file. This mode is used by
                                                       ! json_value_to_string.
@@ -4337,7 +4340,7 @@
     if (.not. exception_thrown) then
 
         !whether to write a string or a file (one or the other):
-        write_string = (iunit==0)
+        write_string = (iunit==unit2str)
         write_file = .not. write_string
 
         !if the comma will be printed after the value

--- a/src/tests/jf_test_7.f90
+++ b/src/tests/jf_test_7.f90
@@ -63,7 +63,7 @@ contains
 
     integer,intent(out) :: error_cnt
 
-    type(json_value),pointer :: root,a,b,c,d,e,e1,e2
+    type(json_value),pointer :: root,a,b,c,d,e,e1,e2,escaped_string
 
     error_cnt = 0
     call json_initialize()
@@ -111,6 +111,7 @@ contains
 !            "int2": 2
 !        }
 !    ]
+!    "escaped string": "\\\/\b\f\n\r\t"
 !}
 
     !create a json structure:
@@ -200,6 +201,22 @@ contains
         call json_print_error_message(error_unit)
         error_cnt = error_cnt + 1
     end if
+        call json_create_object(escaped_string,'escaped string')
+    if (json_failed()) then
+        call json_print_error_message(error_unit)
+        error_cnt = error_cnt + 1
+    end if
+    call json_add(escaped_string,'escaped string',&
+         '\/'//&
+         achar(8)//&
+         achar(12)//&
+         achar(10)//&
+         achar(13)//&
+         achar(9))
+    if (json_failed()) then
+        call json_print_error_message(error_unit)
+        error_cnt = error_cnt + 1
+    end if
 
     call json_add(root,a)
     if (json_failed()) then
@@ -226,6 +243,11 @@ contains
         call json_print_error_message(error_unit)
         error_cnt = error_cnt + 1
     end if
+    call json_add(root,escaped_string)
+    if (json_failed()) then
+        call json_print_error_message(error_unit)
+        error_cnt = error_cnt + 1
+    end if
 
     nullify(a)  !don't need these anymore
     nullify(b)
@@ -234,8 +256,14 @@ contains
     nullify(e)
     nullify(e1)
     nullify(e2)
+    nullify(escaped_string)
 
     call json_print(root,output_unit)  !print to the console
+    if (json_failed()) then
+        call json_print_error_message(error_unit)
+        error_cnt = error_cnt + 1
+    end if
+    call json_print(root,error_unit)  !print to stderr
     if (json_failed()) then
         call json_print_error_message(error_unit)
         error_cnt = error_cnt + 1


### PR DESCRIPTION
I’ve also added a little bit of code to jf_test_7 to verify that you can write json to stderr and to exercise some of the escape_string code.

Btw you may want to turn on and adjust these values too:
https://codecov.io/github/jacobwilliams/json-fortran/features/status