### PR TITLE
Changelog and other small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,11 @@ env:
       # CMake build with unit tests, no documentation, with coverage analysis
       # No unicode so that coverage combined with the build script will cover unicode
       # and non-unicode code paths
-    - BUILD_SCRIPT="mkdir cmake-build && cd cmake-build && cmake -DCMAKE_BUILD_TYPE=COVERAGE .. && make -j 4 check"
+    - >
+      BUILD_SCRIPT="mkdir cmake-build &&
+      cd cmake-build &&
+      cmake -DCMAKE_BUILD_TYPE=COVERAGE .. &&
+      make -j 4 check"
       SPECIFIC_DEPENDS="cmake nodejs"
       JLINT="yes"
       DOCS="yes"
@@ -36,21 +40,50 @@ env:
 
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - if [[ $SPECIFIC_DEPENDS == *cmake* ]]; then sudo apt-add-repository -y ppa:kalakris/cmake; fi
+  - |
+    if [[ $SPECIFIC_DEPENDS == *cmake* ]]; then
+      sudo apt-add-repository -y ppa:kalakris/cmake
+    fi
   - sudo apt-get update -qq
-  - if [[ $JLINT == [yY]* ]]; then curl -sL https://deb.nodesource.com/setup | sudo bash -x - ; fi
-  - if [[ $CHECK_README_PROGS == [yY]* ]]; then wget http://people.sc.fsu.edu/~jburkardt/f_src/f90split/f90split.f90; fi
-  - if [[ $DOCS == [yY]* ]]; then export DEPENDS="$DEPENDS exuberant-ctags"; fi
+  - |
+    if [[ $JLINT == [yY]* ]]; then
+      curl -sL https://deb.nodesource.com/setup | sudo bash -x -
+    fi
+  - |
+    if [[ $CHECK_README_PROGS == [yY]* ]]; then
+      wget http://people.sc.fsu.edu/~jburkardt/f_src/f90split/f90split.f90
+    fi
+  - |
+    if [[ $DOCS == [yY]* ]]; then
+      export DEPENDS="$DEPENDS exuberant-ctags"
+    fi
   - ulimit -s unlimited
 
 install:
   - sudo apt-get install -y $SPECIFIC_DEPENDS $DEPENDS
-  - if [[ $JLINT == [yY]* ]]; then sudo npm install -g jsonlint; fi
+  - |
+    if [[ $JLINT == [yY]* ]]; then
+      sudo npm install -g jsonlint
+    fi
   - sudo ln -fs /usr/bin/gfortran-4.9 /usr/bin/gfortran && gfortran --version
   - sudo ln -fs /usr/bin/gcov-4.9 /usr/bin/gcov && gcov --version
-  - if [[ $FoBiS == [yY]* ]]; then sudo -H pip install FoBiS.py && FoBiS.py --version; fi
-  - if [[ $DOCS == [yY]* ]]; then sudo -H pip install ford && ford --version; fi
-  - if [[ $CHECK_README_PROGS == [yY]* ]]; then gfortran -o f90split f90split.f90 && ./f90split README.md && for f in example*.md; do mv $f src/tests/jf_test_${f%.md}.f90; done; rm f90split.f90 f90split; fi
+  - |
+    if [[ $FoBiS == [yY]* ]]; then
+      sudo -H pip install FoBiS.py && FoBiS.py --version
+    fi
+  - |
+    if [[ $DOCS == [yY]* ]]; then
+      sudo -H pip install ford && ford --version
+    fi
+  - |
+    if [[ $CHECK_README_PROGS == [yY]* ]]; then
+      gfortran -o f90split f90split.f90 && \
+      ./f90split README.md && \
+      for f in example*.md; do
+        mv $f src/tests/jf_test_${f%.md}.f90
+      done
+      rm f90split.f90 f90split
+    fi
 
 script:
   - echo $BUILD_SCRIPT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 ## [4.1.1](https://github.com/jacobwilliams/json-fortran/tree/4.1.1) (2015-05-27)
 
 [Full Changelog](https://github.com/jacobwilliams/json-fortran/compare/4.1.0...4.1.1)
+or [Download v4.1.1](https://github.com/jacobwilliams/json-fortran/releases/tag/4.1.1)
 
 **Enhancements**
 
@@ -90,6 +91,7 @@
 ## [4.1.0](https://github.com/jacobwilliams/json-fortran/tree/4.1.0) (2015-05-05)
 
 [Complete Changeset](https://github.com/jacobwilliams/json-fortran/compare/4.0.0...4.1.0)
+or [Download v4.1.0](https://github.com/jacobwilliams/json-fortran/releases/tag/4.1.0)
 
 **Enhancements:**
 
@@ -110,6 +112,7 @@
 ## [4.0.0](https://github.com/jacobwilliams/json-fortran/tree/4.0.0) (2015-03-16)
 
 [Complete Changeset](https://github.com/jacobwilliams/json-fortran/compare/3.1.0...4.0.0)
+or [Download v4.0.0](https://github.com/jacobwilliams/json-fortran/releases/tag/4.0.0)
 
 **Enhancements**
 
@@ -180,6 +183,7 @@
 ## [3.1.0](https://github.com/jacobwilliams/json-fortran/tree/3.1.0) (2015-02-28)
 
 [Complete Changeset](https://github.com/jacobwilliams/json-fortran/compare/3.0.0...3.1.0)
+or [Download v3.1.0](https://github.com/jacobwilliams/json-fortran/releases/tag/3.1.0)
 
 **Enhancements:**
 
@@ -251,6 +255,7 @@
 ## [3.0.0](https://github.com/jacobwilliams/json-fortran/tree/3.0.0) (2015-01-18)
 
 [Complete Changeset](https://github.com/jacobwilliams/json-fortran/compare/2.0.0...3.0.0)
+or [Download v3.0.0](https://github.com/jacobwilliams/json-fortran/releases/tag/3.0.0)
 
 **Fixed issues:**
 
@@ -285,6 +290,7 @@
 ## [2.0.0](https://github.com/jacobwilliams/json-fortran/tree/2.0.0) (2014-12-27)
 
 [Complete Changeset](https://github.com/jacobwilliams/json-fortran/compare/1.0.0...2.0.0)
+or [Download v2.0.0](https://github.com/jacobwilliams/json-fortran/releases/tag/2.0.0)
 
 **Enhancements:**
 - Significant changes to the API including new procedures
@@ -299,6 +305,8 @@
 
 
 ## [1.0.0](https://github.com/jacobwilliams/json-fortran/tree/1.0.0) (2014-06-23)
+
+[Download v1.0.0](https://github.com/jacobwilliams/json-fortran/releases/tag/1.0.0)
 
 **Enhancements:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+**Table of Contents**
+
+- [Change Log](#change-log)
+    - [Unreleased](#unreleased)
+    - [4.1.1 (2015-05-27)](#411-2015-05-27)
+    - [4.1.0 (2015-05-05)](#410-2015-05-05)
+    - [4.0.0 (2015-03-16)](#400-2015-03-16)
+    - [3.1.0 (2015-02-28)](#310-2015-02-28)
+    - [3.0.0 (2015-01-18)](#300-2015-01-18)
+    - [2.0.0 (2014-12-27)](#200-2014-12-27)
+    - [1.0.0 (2014-06-23)](#100-2014-06-23)
+
 ## [Unreleased](https://github.com/jacobwilliams/json-fortran/tree/HEAD)
 
 [Full Changelog](https://github.com/jacobwilliams/json-fortran/compare/4.1.1...HEAD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@
 [Full Changelog](https://github.com/jacobwilliams/json-fortran/compare/4.1.1...HEAD)
 
 **Enhancements**
+- Add a
+  [CHANGELOG](https://github.com/jacobwilliams/json-fortran/blob/master/CHANGELOG.md)
+  [\#120](https://github.com/jacobwilliams/json-fortran/issues/120)
+  via
+  [PR \#123](https://github.com/jacobwilliams/json-fortran/pull/123)
+  from [zbeekman](https://github.com/zbeekman)
+- Spell 'Fortran' correctly
+  [\#118](https://github.com/jacobwilliams/json-fortran/issues/118)
+  via
+  [PR \#124](https://github.com/jacobwilliams/json-fortran/pull/124)
+  from [zbeekman](https://github.com/zbeekman)
 - Migrate to
   [Codecov.io](https://codecov.io/github/jacobwilliams/json-fortran?branch=master)
   [\#106](https://github.com/jacobwilliams/json-fortran/issues/106)
@@ -31,6 +42,12 @@
 
 **Fixed issues:**
 
+- Fixed innacurate coverage reports via
+  [PR \#109](https://github.com/jacobwilliams/json-fortran/pull/109)
+  from [zbeekman](https://github.com/zbeekman)
+- Fixed a small consistency issue when outputing floating point
+  numbers via
+  [PR \#125](https://github.com/jacobwilliams/json-fortran/pull/125)
 - Problems writing JSON to `error_unit` (0) due to JSON-Fortran's
   special interpretation of `unit=0`
   [\#85](https://github.com/jacobwilliams/json-fortran/issues/85)
@@ -46,10 +63,6 @@
 - Documentation fixes & coverage improvements
   [\#112](https://github.com/jacobwilliams/json-fortran/pull/112)
   ([zbeekman](https://github.com/zbeekman))
-- Small FoBiS coverage fix
-  [\#109](https://github.com/jacobwilliams/json-fortran/pull/109)
-  ([zbeekman](https://github.com/zbeekman))
-
 
 
 ## [4.1.1](https://github.com/jacobwilliams/json-fortran/tree/4.1.1) (2015-05-27)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,14 @@ Looking to contribute something to [json-fortran](README.md)? **Here's how you c
 - Try not to pollute your pull request with unintended changes--keep them simple and small
 - Pull requests should address one issue at a time, and each commit should be a set of self contained, related changes. If you forget something in a commit, please use `git rebase -i <ref>^` to amend and/or squash erroneous commits. Here `<ref>` is the reference to to oldest commit needing to be modified (SHA, or `HEAD~4`, etc.)
 - Each commit should compile, and ideally pass the tests. Very complicated new features or fixes, may have commits that don't pass tests, if otherwise the commit history would include far to many changes in any given commit. Use an interactive rebase to fix any of these issues, as described above.
+- Each commit should have a concise, descriptive message following the
+  guidlines laid out
+  [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+- Make sure to document your changes in the
+  [CHANGELOG](https://github.com/jacobwilliams/json-fortran/blob/master/CHANGELOG.md)
+  under the
+  ['unreleased'](https://github.com/jacobwilliams/json-fortran/blob/master/CHANGELOG.md#unreleased)
+  heading.
 - Pull requests should always be based on the upstream master,
 `jacobwilliams/json-fortran:master`. Please `rebase` your branch on top
 of the latest upstream master. Assuming you are on your branch and you've added the upstream remote by running something like:

--- a/README.md
+++ b/README.md
@@ -26,13 +26,17 @@ A Fortran 2008 JSON API
 Status
 ------
 [![Build Status](https://img.shields.io/travis/jacobwilliams/json-fortran/master.svg?style=plastic)](https://travis-ci.org/jacobwilliams/json-fortran)
-[![codecov.io](http://codecov.io/github/jacobwilliams/json-fortran/coverage.svg?branch=master)](http://codecov.io/github/jacobwilliams/json-fortran?branch=master)<br/>
+[![Codecov](https://img.shields.io/codecov/c/github/jacobwilliams/json-fortran.svg?style=plastic)](http://codecov.io/github/jacobwilliams/json-fortran?branch=master)
+
 [![GitHub issues](https://img.shields.io/github/issues/jacobwilliams/json-fortran.png?style=plastic)](https://github.com/jacobwilliams/json-fortran/issues)
 [![Blocked by Vendor Bug](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=vendor%20bug&title=Blocked%20by%20Vendor%20Bug)](https://waffle.io/jacobwilliams/json-fortran)
 [![Ready in backlog](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=Ready&title=Ready)](https://github.com/jacobwilliams/json-fortran/#contributing)
 [![In Progress](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=In%20Progress&title=In%20Progress)](https://waffle.io/jacobwilliams/json-fortran)
 [![Needs Review](https://badge.waffle.io/jacobwilliams/json-fortran.png?label=Needs%20Review&title=Needs%20Review)](https://waffle.io/jacobwilliams/json-fortran)
 
+Take a look at the
+[CHANGELOG](https://github.com/jacobwilliams/json-fortran/blob/master/CHANGELOG.md#unreleased)
+for a list of changes since the latest release.
 [top](#json-fortran)
 
 Brief description

--- a/json-fortran.md
+++ b/json-fortran.md
@@ -5,7 +5,7 @@ macro: USE_UCS4
 output_dir: ./doc
 media_dir: ./media
 project_github: https://github.com/jacobwilliams/json-fortran
-summary: JSON-FORTRAN -- A Fortran 2008 JSON API
+summary: JSON-Fortran -- A Fortran 2008 JSON API
 author: Jacob Williams
 github: https://github.com/jacobwilliams
 website: http://degenerateconic.com

--- a/src/json_module.F90
+++ b/src/json_module.F90
@@ -2,7 +2,7 @@
 !> author: Jacob Williams
 !  license: BSD
 !
-!# JSON-FORTRAN:
+!# JSON-Fortran:
 !  A Fortran 2008 JSON (JavaScript Object Notation) API.
 !
 !  [TOC]
@@ -22,12 +22,12 @@
 !      The documentation given here assumes ```USE_UCS4``` **is not** defined.
 #endif
 !
-!@warning ```CK``` and ```CDK``` are the json-fortran character kind and json-fortran default
+!@warning ```CK``` and ```CDK``` are the JSON-Fortran character kind and JSON-Fortran default
 !         character kind respectively. Client code **MUST** ensure characters of ```kind=CK```
-!         are used for all character variables and strings passed to the json-fortran
+!         are used for all character variables and strings passed to the JSON-Fortran
 !         library *EXCEPT* for file names which must be of ```'DEFAULT'``` character kind,
 !         provided here as ```CDK```. In particular, any variable that is a: json path, string
-!         value or object name passed to the json-fortran library **MUST** be of type ```CK```.
+!         value or object name passed to the JSON-Fortran library **MUST** be of type ```CK```.
 !
 !@note Most string literal constants of default kind are fine to pass as arguments to
 !      JSON-Fortran procedures since they have been overloaded to accept ```intent(in)```
@@ -37,7 +37,7 @@
 !
 !## License
 !
-!  **json-fortran License:**
+!  **JSON-Fortran License:**
 !
 !    JSON-Fortran: A Fortran 2008 JSON API
 !
@@ -151,7 +151,7 @@
 
     !*********************************************************
     !>
-    !  Default character kind used by json-fortran.
+    !  Default character kind used by JSON-Fortran.
     !  If ISO 10646 (UCS4) support is available, use that,
     !  otherwise, gracefully fall back on 'DEFAULT' characters.
     !  Currently only gfortran >= 4.9.2 will correctly support
@@ -1550,7 +1550,7 @@
 !> author: Jacob Williams
 !  date: 12/4/2013
 !
-!  Initialize the json-fortran module.
+!  Initialize the JSON-Fortran module.
 !  The routine must be called before any of the routines are used.
 !  It can also be called after using the module and encountering exceptions.
 !


### PR DESCRIPTION
CHANGELOG related enhancements including:
 - ToC
 - Entries in Unreleased that should have been entered in previous commits
 - Links to github release under each release

Fortran capitalization updates that escaped my previous PR due to PR refactoring.
Make .travis.yml more legible by breaking shell `if` and `do` statements and long lines, achieved with tricky YAML