### PR TITLE
Tag documentation fix

### DIFF
--- a/json-fortran.md
+++ b/json-fortran.md
@@ -36,7 +36,7 @@ module file
 The JSON-Fortran source code and related files and documentation are
 distributed under a permissive free software license (BSD-style).  See
 the
-[LICENSE](|url|/page/development-resources/LICENSE.html)
+[LICENSE](http://jacobwilliams.github.io/json-fortran/page/development-resources/LICENSE.html)
 file for more details.
 
 # Official Releases
@@ -45,13 +45,13 @@ The **current stable release** is **{!__VERSION__!}** and can be [downloaded
 on GitHub](https://github.com/jacobwilliams/json-fortran/releases/latest)
 or installed with [Homebrew](http://brew.sh) on Mac OSX. The
 documentation for the current version, **{!__VERSION__!}**, can be
-found [here](|url|/page/releases/{!__VERSION__!}/index.html)[^1], and a
+found [here](http://jacobwilliams.github.io/json-fortran/{!__VERSION__!}/index.html)[^1], and a
 list of changes from the previous version are
-[here](|url|/page/releases/index.html#change-log).
+[here](http://jacobwilliams.github.io/json-fortran/page/releases/index.html#change-log).
 
 A list of all past releases, links to their documentation, and the
 chage log can be found on the
-[releases page](|url|/page/releases/index.html).
+[releases page](http://jacobwilliams.github.io/json-fortran/page/releases/index.html).
 
 # Miscellaneous
 
@@ -64,4 +64,4 @@ chage log can be found on the
 [^1]:
     Documentation for a particular release does not contain links
     back to *general* documentation; use the browser's back button to
-    navigate back to <https://jacobwilliams.github.io/json-fortran/>
+    navigate back to <http://jacobwilliams.github.io/json-fortran/>

--- a/json-fortran.md
+++ b/json-fortran.md
@@ -27,8 +27,8 @@ md_extensions: markdown.extensions.toc
 # Brief description
 
 A user-friendly and object-oriented API for reading and writing JSON files, written in
-modern Fortran (Fortran 2003+).  The source code is a single Fortran
-module file
+modern Fortran (Fortran 2003+).  The source code is
+[a single Fortran module](|url|/module/json_module.html) file
 ([json_module.F90](|url|/sourcefile/json_module.f90.html)).
 
 # License

--- a/json-fortran.md
+++ b/json-fortran.md
@@ -57,9 +57,10 @@ chage log can be found on the
 
 * For more information about JSON, see: <http://www.json.org/>
 
-*[API]: Application Programming Interface--a set of routines, protocols, and tools for building software applications
-*[JSON]: JavaScript Object Notation--A human friendly syntax for storing and exchanging data
+*[API]: Application Programming Interface: a set of routines, protocols, and tools for building software applications
+*[JSON]: JavaScript Object Notation: A human friendly syntax for storing and exchanging data
 *[current stable release]: {!__VERSION__!}
+*[latest stable release]: {!__VERSION__!}
 
 [^1]:
     Documentation for a particular release does not contain links

--- a/json-fortran.md
+++ b/json-fortran.md
@@ -14,8 +14,6 @@ predocmark_alt: >
 predocmark: <
 docmark_alt:
 docmark: !
-exclude_dir: tests
-exclude_dir: introspection
 display: public
          protected
          private


### PR DESCRIPTION
 - Fix a broken link on the main page of documentation that should point to the latest release, but was causing a 404
 - Relative links to FORD “pages” pages were broken when build tag documentation on travis, since, for tags, we skip actually building the “pages” pages. Now all URLs pointing to “pages” pages in json-module.md use a full URL to the “pages” published with the latest master branch. URLs in the source code should follow this convention too, if they point to FORD “pages” pages.
 - Actually process and build test documentation with FORD
 - Add a more prominent link to the `json_module` module documentation on the main page.
 - Some other smallish cleanups.

Let me know if you think it’s worth while releasing a minor patch release for these changes as well as your changes since the last tag. If so I’ll hold of with my Homebrew formula PR and update it with the minor patch release, otherwise I’ll tell them to go ahead and merge it.