### PR TITLE
De-lint shell scripts with spellcheck and debug FORD upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ if ( NOT SKIP_DOC_GEN )
       message ( STATUS "Running FORD to dynamically compute documentation outputs, this could take a while..." )
       execute_process ( COMMAND ${CMAKE_COMMAND} -E remove_directory ${DOC_DIR}
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${DOC_DIR}
-	COMMAND "${FORD}" -q ${MACRO_FLAG} -d "${PROJ_DIR}" -o "${DOC_DIR}" -p "${PAGE_DIR}" "${FORD_PROJECT_FILE}" OUTPUT_QUIET )
+	COMMAND "${FORD}" --debug -q ${MACRO_FLAG} -d "${PROJ_DIR}" -o "${DOC_DIR}" -p "${PAGE_DIR}" "${FORD_PROJECT_FILE}" OUTPUT_QUIET )
     else ()
       message ( STATUS "Re-using cached FORD outputs, rather than regenerating them" )
     endif ()
@@ -190,7 +190,7 @@ if ( NOT SKIP_DOC_GEN )
       list ( APPEND FORD_DEPENDS "${DOC_SRC_FILE}" )
     endforeach ()
     add_custom_command ( OUTPUT ${FORD_OUTPUTS_CACHED}
-      COMMAND "${FORD}" ${MACRO_FLAG} -d "${PROJ_DIR}" -o "${DOC_DIR}" -p "${CMAKE_SOURCE_DIR}/pages" "${FORD_PROJECT_FILE}"
+      COMMAND "${FORD}" --debug ${MACRO_FLAG} -d "${PROJ_DIR}" -o "${DOC_DIR}" -p "${CMAKE_SOURCE_DIR}/pages" "${FORD_PROJECT_FILE}"
       MAIN_DEPENDENCY "${FORD_PROJECT_FILE}"
       DEPENDS ${FORD_DEPENDS}
       COMMENT "Building HTML documentation for ${CMAKE_PROJECT_NAME} using FORD" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,13 @@ if ( NOT SKIP_DOC_GEN )
     else ()
       set ( MACRO_FLAG "" )
     endif ()
+    # Pick the preprocessor to use based on the Fortran compiler
+    if ( "${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel" )
+      set ( FPP "fpp\n" )
+    else ()
+      set ( FPP "gfortran -E\n" ) # default to gfortran -E for gfortran and unsupported compilers
+    endif ()
+    file ( WRITE "${CMAKE_BINARY_DIR}/preprocessor-def.md" "${FPP}" )
     # Dynamically generate the FORD outputs list
     message ( STATUS "Dynamically computing FORD output information..." )
     if ( NOT (DEFINED FORD_OUTPUTS_CACHED) )

--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ BINDIR='./bin/'                 # build directory for unit tests
 LIBDIR='./lib/'                 # build directory for library
 MODCODE='json_module.F90'       # json module file name
 LIBOUT='libjsonfortran.a'       # name of json library
-
+FPP="gfortran -E"               # default to gfortran -E pre-processing
 
 # The following warning might be triggered by ifort unless explicitly silenced:
 # warning #7601: F2008 standard does not allow an internal procedure to be an actual argument procedure name. (R1214.4).
@@ -122,11 +122,13 @@ while [ "$#" -ge "1" ]; do # Get command line arguments while there are more lef
         intel|Intel|INTEL|ifort)
             FCOMPILER='Intel'
             FCOMPILERFLAGS="$INTELCOMPILERFLAGS"
+	    FPP="fpp"
             shift
             ;;
         gnu|Gnu|GNU|gfortran|Gfortran|GFortran|GFORTRAN)
             FCOMPILER='gnu'
             FCOMPILERFLAGS="$GNUCOMPILERFLAGS"
+	    FPP="gfortran -E"
             shift
             ;;
         *)
@@ -134,6 +136,7 @@ while [ "$#" -ge "1" ]; do # Get command line arguments while there are more lef
             echo "Warning: Trying to build with unsupported compiler, $2." 1>&2
             echo "Please ensure you set appropriate --cflags and (single) quote them" 1>&2
             FC="$2"
+	    FPP="gfortran -E" # try gfortran to preprocess as a default
             shift
             ;;
         esac
@@ -344,6 +347,7 @@ if [[ $JF_SKIP_DOCS != [yY]* ]]; then
     if hash ford 2>/dev/null; then
     echo "Building documentation..."
     [[ $TRY_UNICODE = [yY]* ]] && MACRO_FLAG=("-m" "USE_UCS4")
+    echo "$FPP" > preprocessor-def.md # Override via include in project file, until FORD gets CLI for this
     ford --debug "${MACRO_FLAG[@]}" -p "$PAGESDIR" "$FORDMD"
     else
     echo "FORD not found! Install using: sudo pip install ford"

--- a/build.sh
+++ b/build.sh
@@ -343,8 +343,8 @@ echo ""
 if [[ $JF_SKIP_DOCS != [yY]* ]]; then
     if hash ford 2>/dev/null; then
     echo "Building documentation..."
-    [[ $TRY_UNICODE = [yY]* ]] && MACRO_FLAG="-m USE_UCS4"
-    ford $MACRO_FLAG -p $PAGESDIR $FORDMD
+    [[ $TRY_UNICODE = [yY]* ]] && MACRO_FLAG=("-m" "USE_UCS4")
+    ford --debug "${MACRO_FLAG[@]}" -p "$PAGESDIR" "$FORDMD"
     else
     echo "FORD not found! Install using: sudo pip install ford"
     fi

--- a/build.sh
+++ b/build.sh
@@ -59,13 +59,13 @@
 #
 #  REQUIRES
 #    FoBiS.py : https://github.com/szaghi/FoBiS      [version 1.2.5 or later required]
-#    FORD     : https://github.com/cmacmackin/ford   [version 3.0.2 is the one tested]
+#    FORD     : https://github.com/cmacmackin/ford   [version 4.0.0 or later]
 #
 #  AUTHOR
 #    Jacob Williams : 12/27/2014
 #
 
-set -e
+set -o errexit
 
 FORDMD='json-fortran.md'        # FORD options file for building documentation
 DOCDIR='./doc/'                 # build directory for documentation
@@ -97,7 +97,7 @@ FCOMPILER='gnu' #Set default compiler to gfortran
 #       e.g., "./build.sh --compiler intel --coverage no --compiler gnu --coverage" will
 #       perform the build with the GFORTRAN compiler, and coverage analysis
 
-script_name="$(basename $0)"
+script_name="$(basename "$0")"
 
 # usage message
 print_usage () {
@@ -213,7 +213,7 @@ while [ "$#" -ge "1" ]; do # Get command line arguments while there are more lef
             shift
             ;;
         no|No|NO)
-            JF_SKIP_DOCSS="no"
+            JF_SKIP_DOCS="no"
             shift
             ;;
         *)
@@ -226,7 +226,7 @@ while [ "$#" -ge "1" ]; do # Get command line arguments while there are more lef
         exit 0
         ;;
     --clean)
-        rm -r src{,/tests}/*.o $DOCDIR* $LIBDIR* $BINDIR* *.gcov*
+        rm -r -- src{,/tests}/*.o $DOCDIR* $LIBDIR* $BINDIR* *.gcov*
         ;;
     *)
         echo "Unknown flag, \"$1\", passed to ${script_name}!" 2>&1
@@ -254,12 +254,12 @@ fi
 
 if [[ $FCOMPILER == custom ]]; then
     echo "Trying to compile with custom compiler, $FC"
-    CUSTOM="-fc $FC"
+    CUSTOM=("-fc" "$FC")
 fi
 
 if [[ $TRY_UNICODE == [yY]* ]]; then
     echo "Trying to compile library with Unicode/UCS4 support"
-    FoBiS.py build -ch -compiler ${FCOMPILER} ${CUSTOM} -cflags "${FCOMPILERFLAGS}" -dbld "${BINDIR}" -s "${INTROSPECDIR}" -dmod ./ -dobj ./ -t ${UCS4TESTCODE} -o ${UCS4TESTCODE%.f90} -colors
+    FoBiS.py build -ch -compiler "${FCOMPILER}" "${CUSTOM[@]}" -cflags "${FCOMPILERFLAGS}" -dbld "${BINDIR}" -s "${INTROSPECDIR}" -dmod ./ -dobj ./ -t "${UCS4TESTCODE}" -o "${UCS4TESTCODE%.f90}" -colors
     if "${BINDIR}/${UCS4TESTCODE%.f90}"; then
     DEFINES="-DUSE_UCS4 -Wunused-function"
     fi
@@ -269,7 +269,7 @@ fi
 echo ""
 echo "Building library..."
 
-FoBiS.py build -ch -compiler ${FCOMPILER} ${CUSTOM} -cflags "${FCOMPILERFLAGS} ${DEFINES}" ${COVERAGE} ${PROFILING} -dbld ${LIBDIR} -s ${SRCDIR} -dmod ./ -dobj ./ -t ${MODCODE} -o ${LIBOUT} -mklib static -colors
+FoBiS.py build -ch -compiler ${FCOMPILER} "${CUSTOM[@]}" -cflags "${FCOMPILERFLAGS} ${DEFINES}" ${COVERAGE} ${PROFILING} -dbld ${LIBDIR} -s ${SRCDIR} -dmod ./ -dobj ./ -t ${MODCODE} -o ${LIBOUT} -mklib static -colors
 
 #build the unit tests (uses the above library):
 if [[ $JF_SKIP_TESTS != [yY]* ]]; then
@@ -282,7 +282,7 @@ if [[ $JF_SKIP_TESTS != [yY]* ]]; then
     for TEST in "${TESTDIR%/}"/jf_test_*.[fF]90; do
     THIS_TEST=${TEST##*/}
     echo "Build ${THIS_TEST%.[fF]90}"
-    FoBiS.py build -ch -compiler ${FCOMPILER} ${CUSTOM} -cflags "${FCOMPILERFLAGS} ${DEFINES}" ${COVERAGE} ${PROFILING} -dbld ${BINDIR} -s ${TESTDIR} -i ${LIBDIR} -libs ${LIBDIR}/${LIBOUT} -dmod ./ -dobj ./ -t ${THIS_TEST} -o ${THIS_TEST%.[fF]90} -colors
+    FoBiS.py build -ch -compiler ${FCOMPILER} "${CUSTOM[@]}" -cflags "${FCOMPILERFLAGS} ${DEFINES}" ${COVERAGE} ${PROFILING} -dbld "${BINDIR}" -s "${TESTDIR}" -i "${LIBDIR}" -libs "${LIBDIR}/${LIBOUT}" -dmod ./ -dobj ./ -t "${THIS_TEST}" -o "${THIS_TEST%.[fF]90}" -colors
     done
 else
     echo "Skip building the unit tests since \$JF_SKIP_TESTS has been set to 'true'."
@@ -292,17 +292,17 @@ fi
 echo ""
 if [[ $JF_SKIP_TESTS != [yY]* ]] ; then
     echo "Running tests..."
-    cd "$BINDIR"
     OLD_IGNORES="$GLOBIGNORE"
+    # run next commands in subshell to avoid `cd -`
+    (cd "$BINDIR"
     GLOBIGNORE='*.*'
     #
     for TEST in jf_test_*; do
         # It would be nice to run json output printed to stdout through jsonlint, however,
         # some tests output more than one json structure and these need to be split
         echo "Running ${TEST}"
-        ./${TEST}
-    done
-    cd -
+        "./${TEST}"
+    done)
     GLOBIGNORE="$OLD_IGNORES"
     if [[ $CODE_COVERAGE = [yY]* ]] ; then
         for SRCFILE in json_string_utilities.F90 json_value_module.F90 json_file_module.F90 ; do

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,14 +3,16 @@
 # If running under travis-ci this will automatically deploy updates to the master branch's
 # documentation on build events for the master branch, and will add/update documentation for
 # any new/updated tags that are pushed.
+set -o errexit
+set -o verbose
 if [ "$TRAVIS" ]; then #running under travis
     if $TRAVIS_SECURE_ENV_VARS ; then
 	# only try to update master's development documentation
 	if [ "$TRAVIS_BRANCH" = "master" ] && \
 	       [ "$TRAVIS_PULL_REQUEST" = "false" ] && \
-	       [ "$(ls -A $TRAVIS_BUILD_DIR/doc)" ] ; then #not empty
-            git clone --branch=gh-pages https://${GH_TOKEN}@github.com/$TRAVIS_REPO_SLUG gh-pages
-            cd gh-pages
+	       [ "$(ls -A "$TRAVIS_BUILD_DIR/doc")" ] ; then #not empty
+            git clone --branch=gh-pages "https://${GH_TOKEN}@github.com/$TRAVIS_REPO_SLUG" gh-pages
+            cd gh-pages || exit 1
 	    rm -r css favicon.png fonts index.html interface js lists media module page proc \
 	       program search.html sourcefile src tipuesearch type
 	    cp -r "$TRAVIS_BUILD_DIR"/doc/* .
@@ -19,13 +21,13 @@ if [ "$TRAVIS" ]; then #running under travis
             git push origin gh-pages
 	fi
 	# If publishing a new/updated tag, deploy it's documentation
-	if [ "$TRAVIS_TAG" ] && [ "$(ls -A $TRAVIS_BUILD_DIR/doc)" ] ; then #not empty
-	    cd "$TRAVIS_BUILD_DIR"
-	    git clone --branch=gh-pages https://${GH_TOKEN}@github.com/$TRAVIS_REPO_SLUG gh-pages
+	if [ "$TRAVIS_TAG" ] && [ "$(ls -A "$TRAVIS_BUILD_DIR/doc")" ] ; then #not empty
+	    cd "$TRAVIS_BUILD_DIR" || exit 1
+	    git clone --branch=gh-pages "https://${GH_TOKEN}@github.com/$TRAVIS_REPO_SLUG" gh-pages
 	    sed "1 s/^/version: ${TRAVIS_TAG}\n/" json-fortran.md > json-fortran.tagged.md
 	    # rebuild FORD documentation without pages, with version info, wiping out any existing tag folder
 	    ford -o "gh-pages/$TRAVIS_TAG" json-fortran.tagged.md
-	    cd gh-pages
+	    cd gh-pages || exit 1
 	    git add -A # add all new files in $TRAVIS_TAG/
 	    git commit -m "Tag/release documentation updated by travis job $TRAVIS_JOB_NUMBER for tag $TRAVIS_TAG $TRAVIS_COMMIT"
 	    git push origin gh-pages

--- a/json-fortran.md
+++ b/json-fortran.md
@@ -1,5 +1,6 @@
 ---
 project: JSON-Fortran
+preprocessor: {!preprocessor-def.md!}
 favicon: ./media/json-fortran-32x32.png
 project_dir: ./src
 output_dir: ./doc

--- a/json-fortran.md
+++ b/json-fortran.md
@@ -21,6 +21,9 @@ display: public
          private
 source: true
 graph: true
+coloured_edges: true
+print_creation_date: true
+creation_date: %Y-%m-%d %H:%M %z
 exclude_dir: tests
 extra_mods: iso_fortran_env:https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fFORTRAN_005fENV.html
 md_extensions: markdown.extensions.toc(anchorlink=False)

--- a/preprocessor-def.md
+++ b/preprocessor-def.md
@@ -1,0 +1,1 @@
+gfortran -E


### PR DESCRIPTION
FORD has introduced some sort of regression that causes it to fail when processing the unicode enabled JSON-Fortran... and maybe the normal JSON-Fortran...

There's no downside of always passing `--debug` to FORD, AFAICT, so I've added it to the CMake and build.sh scripts...

We should probably wait until FORD gets fixed to merge this... and also make sure that we re-trigger the CI builds after FORD is fixed, otherwise the documentation may be incorrect...

See https://github.com/cmacmackin/ford/issues/139#issuecomment-223824644 for more info....