### PR TITLE
json_file updates

### DIFF
--- a/src/json_value_module.F90
+++ b/src/json_value_module.F90
@@ -570,7 +570,7 @@
         !````fortran
         !    type(json_core) :: json
         !    type(json_value),pointer :: p
-        !    call json%create_integer(p,'value',42)
+        !    call json%create_integer(p,42,'value')
         !````
         generic,public :: create_integer => MAYBEWRAP(json_value_create_integer)
         procedure :: MAYBEWRAP(json_value_create_integer)
@@ -7690,8 +7690,8 @@
 
     class(json_core),intent(inout)      :: json
     type(json_value),pointer            :: p
-    character(kind=CK,len=*),intent(in) :: name  !! variable name
     logical(LK),intent(in)              :: val   !! variable value
+    character(kind=CK,len=*),intent(in) :: name  !! variable name
 
     call json_value_create(p)
     call to_logical(p,val,name)
@@ -7711,8 +7711,8 @@
 
     class(json_core),intent(inout)       :: json
     type(json_value),pointer             :: p
-    character(kind=CDK,len=*),intent(in) :: name
     logical(LK),intent(in)               :: val
+    character(kind=CDK,len=*),intent(in) :: name
 
     call json%create_logical(p,val,to_unicode(name))
 
@@ -7738,8 +7738,8 @@
 
     class(json_core),intent(inout)      :: json
     type(json_value),pointer            :: p
-    character(kind=CK,len=*),intent(in) :: name
     integer(IK),intent(in)              :: val
+    character(kind=CK,len=*),intent(in) :: name
 
     call json_value_create(p)
     call to_integer(p,val,name)
@@ -7760,8 +7760,8 @@
 
     class(json_core),intent(inout)       :: json
     type(json_value),pointer             :: p
-    character(kind=CDK,len=*),intent(in) :: name
     integer(IK),intent(in)               :: val
+    character(kind=CDK,len=*),intent(in) :: name
 
     call json%create_integer(p,val,to_unicode(name))
 
@@ -7787,8 +7787,8 @@
 
     class(json_core),intent(inout)      :: json
     type(json_value),pointer            :: p
-    character(kind=CK,len=*),intent(in) :: name
     real(RK),intent(in)                 :: val
+    character(kind=CK,len=*),intent(in) :: name
 
     call json_value_create(p)
     call to_double(p,val,name)
@@ -7809,8 +7809,8 @@
 
     class(json_core),intent(inout)       :: json
     type(json_value),pointer             :: p
-    character(kind=CDK,len=*),intent(in) :: name
     real(RK),intent(in)                  :: val
+    character(kind=CDK,len=*),intent(in) :: name
 
     call json%create_double(p,val,to_unicode(name))
 
@@ -7836,8 +7836,8 @@
 
     class(json_core),intent(inout)      :: json
     type(json_value),pointer            :: p
-    character(kind=CK,len=*),intent(in) :: name
     character(kind=CK,len=*),intent(in) :: val
+    character(kind=CK,len=*),intent(in) :: name
 
     call json_value_create(p)
     call to_string(p,val,name)
@@ -7858,8 +7858,8 @@
 
     class(json_core),intent(inout)       :: json
     type(json_value),pointer             :: p
-    character(kind=CDK,len=*),intent(in) :: name
     character(kind=CDK,len=*),intent(in) :: val
+    character(kind=CDK,len=*),intent(in) :: name
 
     call json%create_string(p,to_unicode(val),to_unicode(name))
 

--- a/src/tests/jf_test_26.f90
+++ b/src/tests/jf_test_26.f90
@@ -14,7 +14,7 @@ contains
     integer,intent(out) :: error_cnt
 
     type(json_core) :: json
-    type(json_value),pointer :: p
+    type(json_value),pointer :: p,tmp
     type(json_file) :: f
     logical(lk) :: is_valid
     character(kind=CK,len=:),allocatable :: error_msg
@@ -39,6 +39,12 @@ contains
     call f%add(ck_'test.vector.unicode(2)',  [cdk_'ck, cdk'])
     call f%add(cdk_'test.vector.unicode(3)', [ck_'cdk, ck'])
     call f%add(cdk_'test.vector.unicode(4)', [cdk_'cdk, cdk'])
+
+    !add a json_value pointer:
+    call json%create_integer(tmp,999,'') ! note that the name will be replaced
+                                         ! with the name given in the path
+                                         ! when it is added.
+    call f%add('inputs.pointer',tmp)
 
     write(error_unit,'(A)') 'validating...'
     call f%get(p)

--- a/src/tests/jf_test_26.f90
+++ b/src/tests/jf_test_26.f90
@@ -1,0 +1,74 @@
+module jf_test_26_mod
+
+use json_module, rk=>json_rk, ik=>json_ik, ck=>json_ck, cdk=>json_cdk, lk=>json_lk
+use, intrinsic :: iso_fortran_env , only: error_unit, output_unit
+
+implicit none
+
+contains
+
+    subroutine test_26(error_cnt)
+
+    implicit none
+
+    integer,intent(out) :: error_cnt
+
+    type(json_core) :: json
+    type(json_value),pointer :: p
+    type(json_file) :: f
+    logical(lk) :: is_valid
+    character(kind=CK,len=:),allocatable :: error_msg
+
+    call f%initialize()  ! specify whatever init options you want.
+
+    write(error_unit,'(A)') 'adding data to json_file...'
+
+    call f%add('inputs.name',     'test case')
+    call f%add('inputs.r',        1.0_rk)
+    call f%add('inputs.rvec',     [1.0_rk,2.0_rk,3.0_rk])
+    call f%add('inputs.i',        1_ik)
+    call f%add('inputs.ivec',     [1_ik,2_ik,3_ik])
+    call f%add('inputs.l',       .true.)
+    call f%add('inputs.lvec',    [ .true. , .false. ] )
+    call f%add(ck_'test.scalar.unicode(1)',  ck_'ck, ck')
+    call f%add(ck_'test.scalar.unicode(2)',  cdk_'ck, cdk')
+    call f%add(cdk_'test.scalar.unicode(3)', ck_'cdk, ck')
+    call f%add(cdk_'test.scalar.unicode(4)', cdk_'cdk, cdk')
+    ! ... note: indentention isn't correct for vector of vectors when printed !TODO
+    call f%add(ck_'test.vector.unicode(1)',  [ck_'ck, ck'])
+    call f%add(ck_'test.vector.unicode(2)',  [cdk_'ck, cdk'])
+    call f%add(cdk_'test.vector.unicode(3)', [ck_'cdk, ck'])
+    call f%add(cdk_'test.vector.unicode(4)', [cdk_'cdk, cdk'])
+
+    write(error_unit,'(A)') 'validating...'
+    call f%get(p)
+    call json%validate(p,is_valid,error_msg)
+    if (.not. is_valid) then
+        write(error_unit,'(A)') 'JSON Validation Error: '//error_msg
+        error_cnt = error_cnt + 1
+        deallocate(error_msg)
+    else
+        write(error_unit,'(A)') '...Success!'
+    end if
+
+    write(error_unit,'(A)') 'printing...'
+    call f%print_file()
+
+    end subroutine test_26
+
+end module jf_test_26_mod
+
+!*****************************************************************************************
+program jf_test_26
+
+    !! 26th unit test.
+
+    use jf_test_26_mod , only: test_26
+    implicit none
+    integer :: n_errors
+    n_errors = 0
+    call test_26(n_errors)
+    if (n_errors /= 0) stop 1
+
+end program jf_test_26
+!*****************************************************************************************


### PR DESCRIPTION
Added methods to add variables by specifying their paths. Fixes #268.
Changed argument to `update` methods from “name” to “path” to match the recent change in `json_value_module`.
Some minor formatting and commenting updates.