### PR TITLE
Replace CMAKE_INSTALL_LIBDIR with INSTALL_LIB_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,5 +410,5 @@ configure_file(
 )
 install(FILES
    "${CMAKE_CURRENT_BINARY_DIR}/json-fortran.pc"
-   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+   DESTINATION "${INSTALL_LIB_DIR}/pkgconfig"
 )


### PR DESCRIPTION
CMAKE_INSTALL_LIBDIR is empty unless USE_GNU_INSTALL_CONVENTION is true, and in both cases INSTALL_LIB_DIRS is set.