### PR TITLE
Better make check output and additional target to build tests at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ if ( ENABLE_TESTS )
   enable_testing()
 
   # emulate GNU Autotools `make check`
-  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG>)
+  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --output-on-failure)
   add_custom_target(build_tests) # Make target to build all tests
   add_dependencies(build_tests ${LIB_NAME} ${LIB_NAME}-static)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,8 @@ if ( ENABLE_TESTS )
 
   # emulate GNU Autotools `make check`
   add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG>)
+  add_custom_target(build_tests) # Make target to build all tests
+  add_dependencies(build_tests ${LIB_NAME} ${LIB_NAME}-static)
 
   find_program ( JSONLINT jsonlint )
   find_program ( DIFF     diff )
@@ -290,6 +292,7 @@ if ( ENABLE_TESTS )
     add_executable ( ${TEST} EXCLUDE_FROM_ALL ${UNIT_TEST} )
     target_link_libraries ( ${TEST} ${LIB_NAME} )
     add_dependencies ( check ${TEST} )
+    add_dependencies ( build_tests ${TEST} )
     set_target_properties ( ${TEST}
       PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )


### PR DESCRIPTION
This adds:
* `--output-on-failure` to the `make check` target; this will print the output for a failed test
* a `build_tests` target to allow the compilation of the tests and libraries at build time. This is useful for consuming JSON-Fortran in a CMake SuperBuild, because CMake's `ExternalProject_Add()` assumes that the `test` target or the `ctest` commands will just work.