### PR TITLE
adding default optional args to get by path routines

### DIFF
--- a/src/json_file_module.F90
+++ b/src/json_file_module.F90
@@ -1876,7 +1876,7 @@
 !  Get an (allocatable length) string vector from a JSON file.
 !  This is just a wrapper for [[json_get_alloc_string_vec_by_path]].
 
-    subroutine json_file_get_alloc_string_vec(me, path, vec, ilen, found)
+    subroutine json_file_get_alloc_string_vec(me, path, vec, ilen, found, default, default_ilen)
 
     implicit none
 
@@ -1887,8 +1887,11 @@
                                                              !! of each character
                                                              !! string in the array
     logical(LK),intent(out),optional :: found
+    character(kind=CK,len=*),dimension(:),intent(in),optional :: default
+    integer(IK),dimension(:),intent(in),optional :: default_ilen !! the actual
+                                                                 !! length of `default`
 
-    call me%core%get(me%p, path, vec, ilen, found)
+    call me%core%get(me%p, path, vec, ilen, found, default, default_ilen)
 
     end subroutine json_file_get_alloc_string_vec
 !*****************************************************************************************
@@ -1898,7 +1901,7 @@
 !  Alternate version of [[json_file_get_alloc_string_vec]], where "path" is kind=CDK.
 !  This is just a wrapper for [[wrap_json_get_alloc_string_vec_by_path]].
 
-    subroutine wrap_json_file_get_alloc_string_vec(me, path, vec, ilen, found)
+    subroutine wrap_json_file_get_alloc_string_vec(me, path, vec, ilen, found, default, default_ilen)
 
     implicit none
 
@@ -1909,8 +1912,11 @@
                                                              !! of each character
                                                              !! string in the array
     logical(LK),intent(out),optional :: found
+    character(kind=CK,len=*),dimension(:),intent(in),optional :: default
+    integer(IK),dimension(:),intent(in),optional :: default_ilen !! the actual
+                                                                 !! length of `default`
 
-    call me%get(to_unicode(path), vec, ilen, found)
+    call me%get(to_unicode(path), vec, ilen, found, default, default_ilen)
 
     end subroutine wrap_json_file_get_alloc_string_vec
 !*****************************************************************************************

--- a/src/json_file_module.F90
+++ b/src/json_file_module.F90
@@ -1361,7 +1361,7 @@
     type(json_value),pointer,intent(out) :: p      !! pointer to the variable
     logical(LK),intent(out),optional     :: found  !! if it was really found
 
-    call me%core%get(me%p, path=path, p=p, found=found)
+    call me%core%get(me%p, path, p, found)
 
     end subroutine json_file_get_object
 !*****************************************************************************************
@@ -1390,16 +1390,17 @@
 !
 !  Get an integer value from a JSON file.
 
-    subroutine json_file_get_integer(me, path, val, found)
+    subroutine json_file_get_integer(me, path, val, found, default)
 
     implicit none
 
     class(json_file),intent(inout)      :: me
-    character(kind=CK,len=*),intent(in) :: path   !! the path to the variable
-    integer(IK),intent(out)             :: val    !! value
-    logical(LK),intent(out),optional    :: found  !! if it was really found
+    character(kind=CK,len=*),intent(in) :: path    !! the path to the variable
+    integer(IK),intent(out)             :: val     !! value
+    logical(LK),intent(out),optional    :: found   !! if it was really found
+    integer(IK),intent(in),optional     :: default
 
-    call me%core%get(me%p, path=path, value=val, found=found)
+    call me%core%get(me%p, path, val, found, default)
 
     end subroutine json_file_get_integer
 !*****************************************************************************************
@@ -1408,7 +1409,7 @@
 !>
 !  Alternate version of [[json_file_get_integer]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_integer(me, path, val, found)
+    subroutine wrap_json_file_get_integer(me, path, val, found, default)
 
     implicit none
 
@@ -1416,8 +1417,9 @@
     character(kind=CDK,len=*),intent(in) :: path   !! the path to the variable
     integer(IK),intent(out)              :: val    !! value
     logical(LK),intent(out),optional     :: found  !! if it was really found
+    integer(IK),intent(in),optional      :: default
 
-    call me%get(to_unicode(path), val, found)
+    call me%get(to_unicode(path), val, found, default)
 
     end subroutine wrap_json_file_get_integer
 !*****************************************************************************************
@@ -1428,7 +1430,7 @@
 !
 !  Get an integer vector from a JSON file.
 
-    subroutine json_file_get_integer_vec(me, path, vec, found)
+    subroutine json_file_get_integer_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1436,8 +1438,9 @@
     character(kind=CK,len=*),intent(in)              :: path   !! the path to the variable
     integer(IK),dimension(:),allocatable,intent(out) :: vec    !! the value vector
     logical(LK),intent(out),optional                 :: found  !! if it was really found
+    integer(IK),dimension(:),intent(in),optional     :: default
 
-    call me%core%get(me%p, path, vec, found)
+    call me%core%get(me%p, path, vec, found, default)
 
     end subroutine json_file_get_integer_vec
 !*****************************************************************************************
@@ -1446,7 +1449,7 @@
 !>
 !  Alternate version of [[json_file_get_integer_vec]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_integer_vec(me, path, vec, found)
+    subroutine wrap_json_file_get_integer_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1454,8 +1457,9 @@
     character(kind=CDK,len=*),intent(in)             :: path  !! the path to the variable
     integer(IK),dimension(:),allocatable,intent(out) :: vec   !! the value vector
     logical(LK),intent(out),optional                 :: found !! if it was really found
+    integer(IK),dimension(:),intent(in),optional     :: default
 
-    call me%get(to_unicode(path), vec, found)
+    call me%get(to_unicode(path), vec, found, default)
 
     end subroutine wrap_json_file_get_integer_vec
 !*****************************************************************************************
@@ -1466,7 +1470,7 @@
 !
 !  Get a real(RK) variable value from a JSON file.
 
-    subroutine json_file_get_real (me, path, val, found)
+    subroutine json_file_get_real (me, path, val, found, default)
 
     implicit none
 
@@ -1474,8 +1478,9 @@
     character(kind=CK,len=*),intent(in) :: path  !! the path to the variable
     real(RK),intent(out)                :: val   !! value
     logical(LK),intent(out),optional    :: found !! if it was really found
+    real(RK),intent(in),optional        :: default
 
-    call me%core%get(me%p, path=path, value=val, found=found)
+    call me%core%get(me%p, path, val, found, default)
 
     end subroutine json_file_get_real
 !*****************************************************************************************
@@ -1484,7 +1489,7 @@
 !>
 !  Alternate version of [[json_file_get_real]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_real (me, path, val, found)
+    subroutine wrap_json_file_get_real (me, path, val, found, default)
 
     implicit none
 
@@ -1492,8 +1497,9 @@
     character(kind=CDK,len=*),intent(in) :: path  !! the path to the variable
     real(RK),intent(out)                 :: val   !! value
     logical(LK),intent(out),optional     :: found !! if it was really found
+    real(RK),intent(in),optional         :: default
 
-    call me%get(to_unicode(path), val, found)
+    call me%get(to_unicode(path), val, found, default)
 
     end subroutine wrap_json_file_get_real
 !*****************************************************************************************
@@ -1504,7 +1510,7 @@
 !
 !  Get a real(RK) vector from a JSON file.
 
-    subroutine json_file_get_real_vec(me, path, vec, found)
+    subroutine json_file_get_real_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1512,8 +1518,9 @@
     character(kind=CK,len=*),intent(in)           :: path  !! the path to the variable
     real(RK),dimension(:),allocatable,intent(out) :: vec   !! the value vector
     logical(LK),intent(out),optional              :: found !! if it was really found
+    real(RK),dimension(:),intent(in),optional     :: default
 
-    call me%core%get(me%p, path, vec, found)
+    call me%core%get(me%p, path, vec, found, default)
 
     end subroutine json_file_get_real_vec
 !*****************************************************************************************
@@ -1522,7 +1529,7 @@
 !>
 !  Alternate version of [[json_file_get_real_vec]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_real_vec(me, path, vec, found)
+    subroutine wrap_json_file_get_real_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1530,8 +1537,9 @@
     character(kind=CDK,len=*),intent(in)          :: path  !! the path to the variable
     real(RK),dimension(:),allocatable,intent(out) :: vec   !! the value vector
     logical(LK),intent(out),optional              :: found !! if it was really found
+    real(RK),dimension(:),intent(in),optional     :: default
 
-    call me%get(to_unicode(path), vec, found)
+    call me%get(to_unicode(path), vec, found, default)
 
     end subroutine wrap_json_file_get_real_vec
 !*****************************************************************************************
@@ -1543,7 +1551,7 @@
 !
 !  Alternate version of [[json_file_get_real]] where `val` is `real32`.
 
-    subroutine json_file_get_real32 (me, path, val, found)
+    subroutine json_file_get_real32 (me, path, val, found, default)
 
     implicit none
 
@@ -1551,8 +1559,9 @@
     character(kind=CK,len=*),intent(in) :: path  !! the path to the variable
     real(real32),intent(out)            :: val   !! value
     logical(LK),intent(out),optional    :: found !! if it was really found
+    real(real32),intent(in),optional    :: default
 
-    call me%core%get(me%p, path=path, value=val, found=found)
+    call me%core%get(me%p, path, val, found, default)
 
     end subroutine json_file_get_real32
 !*****************************************************************************************
@@ -1561,7 +1570,7 @@
 !>
 !  Alternate version of [[json_file_get_real32]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_real32 (me, path, val, found)
+    subroutine wrap_json_file_get_real32 (me, path, val, found, default)
 
     implicit none
 
@@ -1569,8 +1578,9 @@
     character(kind=CDK,len=*),intent(in) :: path  !! the path to the variable
     real(real32),intent(out)             :: val   !! value
     logical(LK),intent(out),optional     :: found !! if it was really found
+    real(real32),intent(in),optional     :: default
 
-    call me%get(to_unicode(path), val, found)
+    call me%get(to_unicode(path), val, found, default)
 
     end subroutine wrap_json_file_get_real32
 !*****************************************************************************************
@@ -1581,7 +1591,7 @@
 !
 !  Alternate version of [[json_file_get_real_vec]] where `vec` is `real32`.
 
-    subroutine json_file_get_real32_vec(me, path, vec, found)
+    subroutine json_file_get_real32_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1589,8 +1599,9 @@
     character(kind=CK,len=*),intent(in)               :: path  !! the path to the variable
     real(real32),dimension(:),allocatable,intent(out) :: vec   !! the value vector
     logical(LK),intent(out),optional                  :: found !! if it was really found
+    real(real32),dimension(:),intent(in),optional     :: default
 
-    call me%core%get(me%p, path, vec, found)
+    call me%core%get(me%p, path, vec, found, default)
 
     end subroutine json_file_get_real32_vec
 !*****************************************************************************************
@@ -1599,7 +1610,7 @@
 !>
 !  Alternate version of [[json_file_get_real32_vec]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_real32_vec(me, path, vec, found)
+    subroutine wrap_json_file_get_real32_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1607,8 +1618,9 @@
     character(kind=CDK,len=*),intent(in)              :: path  !! the path to the variable
     real(real32),dimension(:),allocatable,intent(out) :: vec   !! the value vector
     logical(LK),intent(out),optional                  :: found !! if it was really found
+    real(real32),dimension(:),intent(in),optional     :: default
 
-    call me%get(to_unicode(path), vec, found)
+    call me%get(to_unicode(path), vec, found, default)
 
     end subroutine wrap_json_file_get_real32_vec
 !*****************************************************************************************
@@ -1621,7 +1633,7 @@
 !
 !  Alternate version of [[json_file_get_real]] where `val` is `real64`.
 
-    subroutine json_file_get_real64 (me, path, val, found)
+    subroutine json_file_get_real64 (me, path, val, found, default)
 
     implicit none
 
@@ -1629,8 +1641,9 @@
     character(kind=CK,len=*),intent(in) :: path  !! the path to the variable
     real(real64),intent(out)            :: val   !! value
     logical(LK),intent(out),optional    :: found !! if it was really found
+    real(real64),intent(in),optional    :: default
 
-    call me%core%get(me%p, path=path, value=val, found=found)
+    call me%core%get(me%p, path, val, found, default)
 
     end subroutine json_file_get_real64
 !*****************************************************************************************
@@ -1639,7 +1652,7 @@
 !>
 !  Alternate version of [[json_file_get_real64]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_real64 (me, path, val, found)
+    subroutine wrap_json_file_get_real64 (me, path, val, found, default)
 
     implicit none
 
@@ -1647,8 +1660,9 @@
     character(kind=CDK,len=*),intent(in) :: path  !! the path to the variable
     real(real64),intent(out)             :: val   !! value
     logical(LK),intent(out),optional     :: found !! if it was really found
+    real(real64),intent(in),optional     :: default
 
-    call me%get(to_unicode(path), val, found)
+    call me%get(to_unicode(path), val, found, default)
 
     end subroutine wrap_json_file_get_real64
 !*****************************************************************************************
@@ -1659,7 +1673,7 @@
 !
 !  Alternate version of [[json_file_get_real_vec]] where `vec` is `real64`.
 
-    subroutine json_file_get_real64_vec(me, path, vec, found)
+    subroutine json_file_get_real64_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1667,8 +1681,9 @@
     character(kind=CK,len=*),intent(in)               :: path  !! the path to the variable
     real(real64),dimension(:),allocatable,intent(out) :: vec   !! the value vector
     logical(LK),intent(out),optional                  :: found !! if it was really found
+    real(real64),dimension(:),intent(in),optional     :: default
 
-    call me%core%get(me%p, path, vec, found)
+    call me%core%get(me%p, path, vec, found, default)
 
     end subroutine json_file_get_real64_vec
 !*****************************************************************************************
@@ -1677,7 +1692,7 @@
 !>
 !  Alternate version of [[json_file_get_real64_vec]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_real64_vec(me, path, vec, found)
+    subroutine wrap_json_file_get_real64_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1685,8 +1700,9 @@
     character(kind=CDK,len=*),intent(in)              :: path  !! the path to the variable
     real(real64),dimension(:),allocatable,intent(out) :: vec   !! the value vector
     logical(LK),intent(out),optional                  :: found !! if it was really found
+    real(real64),dimension(:),intent(in),optional     :: default
 
-    call me%get(to_unicode(path), vec, found)
+    call me%get(to_unicode(path), vec, found, default)
 
     end subroutine wrap_json_file_get_real64_vec
 !*****************************************************************************************
@@ -1698,7 +1714,7 @@
 !
 !  Get a logical(LK) value from a JSON file.
 
-    subroutine json_file_get_logical(me,path,val,found)
+    subroutine json_file_get_logical(me,path,val,found,default)
 
     implicit none
 
@@ -1706,8 +1722,9 @@
     character(kind=CK,len=*),intent(in)  :: path   !! the path to the variable
     logical(LK),intent(out)              :: val    !! value
     logical(LK),intent(out),optional     :: found  !! if it was really found
+    logical(LK),intent(in),optional      :: default
 
-    call me%core%get(me%p, path=path, value=val, found=found)
+    call me%core%get(me%p, path, val, found, default)
 
     end subroutine json_file_get_logical
 !*****************************************************************************************
@@ -1716,7 +1733,7 @@
 !>
 !  Alternate version of [[json_file_get_logical]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_logical(me,path,val,found)
+    subroutine wrap_json_file_get_logical(me,path,val,found,default)
 
     implicit none
 
@@ -1724,8 +1741,9 @@
     character(kind=CDK,len=*),intent(in) :: path   !! the path to the variable
     logical(LK),intent(out)              :: val    !! value
     logical(LK),intent(out),optional     :: found  !! if it was really found
+    logical(LK),intent(in),optional      :: default
 
-    call me%get(to_unicode(path), val, found)
+    call me%get(to_unicode(path), val, found, default)
 
     end subroutine wrap_json_file_get_logical
 !*****************************************************************************************
@@ -1736,7 +1754,7 @@
 !
 !  Get a logical(LK) vector from a JSON file.
 
-    subroutine json_file_get_logical_vec(me, path, vec, found)
+    subroutine json_file_get_logical_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1744,8 +1762,9 @@
     character(kind=CK,len=*),intent(in)              :: path  !! the path to the variable
     logical(LK),dimension(:),allocatable,intent(out) :: vec   !! the value vector
     logical(LK),intent(out),optional                 :: found !! if it was really found
+    logical(LK),dimension(:),intent(in),optional     :: default
 
-    call me%core%get(me%p, path, vec, found)
+    call me%core%get(me%p, path, vec, found, default)
 
     end subroutine json_file_get_logical_vec
 !*****************************************************************************************
@@ -1754,7 +1773,7 @@
 !>
 !  Alternate version of [[json_file_get_logical_vec]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_logical_vec(me, path, vec, found)
+    subroutine wrap_json_file_get_logical_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1762,8 +1781,9 @@
     character(kind=CDK,len=*),intent(in)             :: path  !! the path to the variable
     logical(LK),dimension(:),allocatable,intent(out) :: vec   !! the value vector
     logical(LK),intent(out),optional                 :: found !! if it was really found
+    logical(LK),dimension(:),intent(in),optional     :: default
 
-    call me%get(to_unicode(path), vec, found)
+    call me%get(to_unicode(path), vec, found, default)
 
     end subroutine wrap_json_file_get_logical_vec
 !*****************************************************************************************
@@ -1775,7 +1795,7 @@
 !  Get a character string from a json file.
 !  The output val is an allocatable character string.
 
-    subroutine json_file_get_string(me, path, val, found)
+    subroutine json_file_get_string(me, path, val, found, default)
 
     implicit none
 
@@ -1783,8 +1803,9 @@
     character(kind=CK,len=*),intent(in)              :: path  !! the path to the variable
     character(kind=CK,len=:),allocatable,intent(out) :: val   !! value
     logical(LK),intent(out),optional                 :: found !! if it was really found
+    character(kind=CK,len=*),intent(in),optional     :: default
 
-    call me%core%get(me%p, path=path, value=val, found=found)
+    call me%core%get(me%p, path, val, found, default)
 
     end subroutine json_file_get_string
 !*****************************************************************************************
@@ -1793,7 +1814,7 @@
 !>
 !  Alternate version of [[json_file_get_string]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_string(me, path, val, found)
+    subroutine wrap_json_file_get_string(me, path, val, found, default)
 
     implicit none
 
@@ -1801,8 +1822,9 @@
     character(kind=CDK,len=*),intent(in)             :: path  !! the path to the variable
     character(kind=CK,len=:),allocatable,intent(out) :: val   !! value
     logical(LK),intent(out),optional                 :: found !! if it was really found
+    character(kind=CK,len=*),intent(in),optional     :: default
 
-    call me%get(to_unicode(path), val, found)
+    call me%get(to_unicode(path), val, found, default)
 
     end subroutine wrap_json_file_get_string
 !*****************************************************************************************

--- a/src/json_file_module.F90
+++ b/src/json_file_module.F90
@@ -1835,7 +1835,7 @@
 !
 !  Get a string vector from a JSON file.
 
-    subroutine json_file_get_string_vec(me, path, vec, found)
+    subroutine json_file_get_string_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1843,8 +1843,9 @@
     character(kind=CK,len=*),intent(in)                           :: path  !! the path to the variable
     character(kind=CK,len=*),dimension(:),allocatable,intent(out) :: vec   !! value vector
     logical(LK),intent(out),optional                              :: found !! if it was really found
+    character(kind=CK,len=*),dimension(:),intent(in),optional     :: default
 
-    call me%core%get(me%p, path, vec, found)
+    call me%core%get(me%p, path, vec, found, default)
 
     end subroutine json_file_get_string_vec
 !*****************************************************************************************
@@ -1853,7 +1854,7 @@
 !>
 !  Alternate version of [[json_file_get_string_vec]], where "path" is kind=CDK.
 
-    subroutine wrap_json_file_get_string_vec(me, path, vec, found)
+    subroutine wrap_json_file_get_string_vec(me, path, vec, found, default)
 
     implicit none
 
@@ -1861,8 +1862,9 @@
     character(kind=CDK,len=*),intent(in)                          :: path  !! the path to the variable
     character(kind=CK,len=*),dimension(:),allocatable,intent(out) :: vec   !! value vector
     logical(LK),intent(out),optional                              :: found !! if it was really found
+    character(kind=CK,len=*),dimension(:),intent(in),optional     :: default
 
-    call me%get(to_unicode(path), vec, found)
+    call me%get(to_unicode(path), vec, found, default)
 
     end subroutine wrap_json_file_get_string_vec
 !*****************************************************************************************

--- a/src/json_get_scalar_by_path.inc
+++ b/src/json_get_scalar_by_path.inc
@@ -1,0 +1,32 @@
+    type(json_value),pointer :: p
+
+    if (present(default)) then
+        value = default
+    else
+        value = default_if_not_specified
+    end if
+
+    if ( json%exception_thrown ) then
+       call flag_not_found(found)
+       return
+    end if
+
+    nullify(p)
+    call json%get(me=me, path=path, p=p)
+
+    if (.not. associated(p)) then
+        call json%throw_exception('Error in '//routine//':'//&
+                                  ' Unable to resolve path: '// trim(path),found)
+    else
+        call json%get(p,value)
+    end if
+
+    if ( json%exception_thrown ) then
+        if ( present(found) .or. present(default)) then
+            call flag_not_found(found)
+            if (present(default)) value = default
+            call json%clear_exceptions()
+        end if
+    else
+        if ( present(found) ) found = .true.
+    end if

--- a/src/json_get_vec_by_path.inc
+++ b/src/json_get_vec_by_path.inc
@@ -1,0 +1,27 @@
+    type(json_value),pointer :: p
+
+    if ( json%exception_thrown ) then
+        if (present(default)) vec = default
+        call flag_not_found(found)
+        return
+    end if
+
+    nullify(p)
+    call json%get(me=me, path=path, p=p)
+
+    if (.not. associated(p)) then
+        call json%throw_exception('Error in '//routine//':'//&
+                                  ' Unable to resolve path: '// trim(path),found)
+    else
+        call json%get(p,vec)
+    end if
+
+    if ( json%exception_thrown ) then
+        if ( present(found) .or. present(default)) then
+            call flag_not_found(found)
+            if (present(default)) vec = default
+            call json%clear_exceptions()
+        end if
+    else
+        if ( present(found) ) found = .true.
+    end if

--- a/src/json_get_vec_by_path_alloc.inc
+++ b/src/json_get_vec_by_path_alloc.inc
@@ -1,0 +1,43 @@
+    type(json_value),pointer :: p
+
+    if ( json%exception_thrown ) then
+        if (present(default)) then
+            vec = default
+            if (present(default_ilen)) then
+                ilen = default_ilen
+            else
+                allocate(ilen(size(default)))
+                ilen = len(default)
+            end if
+        end if
+        call flag_not_found(found)
+        return
+    end if
+
+    nullify(p)
+    call json%get(me=me, path=path, p=p)
+
+    if (.not. associated(p)) then
+        call json%throw_exception('Error in '//routine//':'//&
+                                  ' Unable to resolve path: '// trim(path),found)
+    else
+        call json%get(p,vec,ilen)
+    end if
+
+    if ( json%exception_thrown ) then
+        if ( present(found) .or. present(default)) then
+            call flag_not_found(found)
+            if (present(default)) then
+                vec = default
+                if (present(default_ilen)) then
+                    ilen = default_ilen
+                else
+                    allocate(ilen(size(default)))
+                    ilen = len(default)
+                end if
+            end if
+            call json%clear_exceptions()
+        end if
+    else
+        if ( present(found) ) found = .true.
+    end if

--- a/src/json_value_module.F90
+++ b/src/json_value_module.F90
@@ -7754,7 +7754,6 @@
     type(json_value),pointer :: tmp            !! for traversing the structure
     type(json_value),pointer :: element        !! for traversing the structure
     integer(IK)              :: var_type       !! JSON variable type flag
-    integer(IK)              :: tmp_var_type   !! JSON variable type flag
     integer(IK)              :: i              !! counter
     integer(IK)              :: n_children     !! number of children for parent
     logical(LK)              :: use_brackets   !! to use '[]' characters for arrays
@@ -9209,7 +9208,7 @@
 !>
 !  Get a string vector from a [[json_value(type)]], given the path.
 
-    subroutine json_get_string_vec_by_path(json, me, path, vec, found)
+    subroutine json_get_string_vec_by_path(json, me, path, vec, found, default)
 
     implicit none
 
@@ -9218,23 +9217,11 @@
     character(kind=CK,len=*),intent(in)                           :: path
     character(kind=CK,len=*),dimension(:),allocatable,intent(out) :: vec
     logical(LK),intent(out),optional                              :: found
+    character(kind=CK,len=*),dimension(:),intent(in),optional     :: default
 
-    type(json_value),pointer :: p
+    character(kind=CK,len=*),parameter :: routine = CK_'json_get_string_vec_by_path'
 
-    call json%get(me, path, p, found)
-
-    if (present(found)) then
-        if (.not. found) return
-    else
-        if (json%exception_thrown) return
-    end if
-
-    call json%get(p, vec)
-
-    if (present(found) .and. json%exception_thrown) then
-        call json%clear_exceptions()
-        found = .false.
-    end if
+#include "json_get_vec_by_path.inc"
 
     end subroutine json_get_string_vec_by_path
 !*****************************************************************************************
@@ -9243,7 +9230,7 @@
 !>
 !  Alternate version of [[json_get_string_vec_by_path]], where "path" is kind=CDK
 
-    subroutine wrap_json_get_string_vec_by_path(json, me, path, vec, found)
+    subroutine wrap_json_get_string_vec_by_path(json, me, path, vec, found, default)
 
     implicit none
 
@@ -9252,8 +9239,9 @@
     character(kind=CDK,len=*),intent(in)                          :: path
     character(kind=CK,len=*),dimension(:),allocatable,intent(out) :: vec
     logical(LK),intent(out),optional                              :: found
+    character(kind=CK,len=*),dimension(:),intent(in),optional     :: default
 
-    call json%get(me,to_unicode(path),vec,found)
+    call json%get(me,to_unicode(path),vec,found,default)
 
     end subroutine wrap_json_get_string_vec_by_path
 !*****************************************************************************************

--- a/src/json_value_module.F90
+++ b/src/json_value_module.F90
@@ -8052,20 +8052,14 @@
 
     logical(LK) :: status_ok !! error flag for [[string_to_integer]]
 
-    if (.not. json%exception_thrown) then
+    ! call the core routine:
+    call string_to_integer(str,ival,status_ok)
 
-        ! call the core routine:
-        call string_to_integer(str,ival,status_ok)
-
-        if (.not. status_ok) then
-            ival = 0
-            call json%throw_exception('Error in string_to_int: '//&
-                                      'string cannot be converted to an integer: '//&
-                                      trim(str))
-        end if
-
-    else
+    if (.not. status_ok) then
         ival = 0
+        call json%throw_exception('Error in string_to_int: '//&
+                                    'string cannot be converted to an integer: '//&
+                                    trim(str))
     end if
 
     end function string_to_int
@@ -8085,19 +8079,13 @@
 
     logical(LK) :: status_ok  !! error flag for [[string_to_real]]
 
-    if (.not. json%exception_thrown) then
+    call string_to_real(str,json%use_quiet_nan,rval,status_ok)
 
-        call string_to_real(str,json%use_quiet_nan,rval,status_ok)
-
-        if (.not. status_ok) then    !if there was an error
-            rval = 0.0_RK
-            call json%throw_exception('Error in string_to_dble: '//&
-                                      'string cannot be converted to a real: '//&
-                                      trim(str))
-        end if
-
-    else
+    if (.not. status_ok) then    !if there was an error
         rval = 0.0_RK
+        call json%throw_exception('Error in string_to_dble: '//&
+                                  'string cannot be converted to a real: '//&
+                                  trim(str))
     end if
 
     end function string_to_dble

--- a/src/json_value_module.F90
+++ b/src/json_value_module.F90
@@ -9353,8 +9353,12 @@
 !@note An alternative to using this routine is to use [[json_get_array]] with
 !      a callback function that gets the string from each element and populates
 !      a user-defined string type.
+!
+!@note If the `default` argument is used, and `default_ilen` is not present,
+!      then `ilen` will just be returned as the length of the `default` dummy
+!      argument (all elements with the same length).
 
-    subroutine json_get_alloc_string_vec_by_path(json, me, path, vec, ilen, found)
+    subroutine json_get_alloc_string_vec_by_path(json,me,path,vec,ilen,found,default,default_ilen)
 
     implicit none
 
@@ -9366,23 +9370,13 @@
                                                              !! of each character
                                                              !! string in the array
     logical(LK),intent(out),optional :: found
+    character(kind=CK,len=*),dimension(:),intent(in),optional :: default
+    integer(IK),dimension(:),intent(in),optional :: default_ilen !! the actual
+                                                                 !! length of `default`
 
-    type(json_value),pointer :: p
+    character(kind=CK,len=*),parameter :: routine = CK_'json_get_alloc_string_vec_by_path'
 
-    call json%get(me, path, p, found)
-
-    if (present(found)) then
-        if (.not. found) return
-    else
-        if (json%exception_thrown) return
-    end if
-
-    call json%get(p, vec, ilen)
-
-    if (present(found) .and. json%exception_thrown) then
-        call json%clear_exceptions()
-        found = .false.
-    end if
+#include "json_get_vec_by_path_alloc.inc"
 
     end subroutine json_get_alloc_string_vec_by_path
 !*****************************************************************************************
@@ -9391,7 +9385,7 @@
 !>
 !  Alternate version of [[json_get_alloc_string_vec_by_path]], where "path" is kind=CDK
 
-    subroutine wrap_json_get_alloc_string_vec_by_path(json,me,path,vec,ilen,found)
+    subroutine wrap_json_get_alloc_string_vec_by_path(json,me,path,vec,ilen,found,default,default_ilen)
 
     implicit none
 
@@ -9403,8 +9397,11 @@
                                                              !! of each character
                                                              !! string in the array
     logical(LK),intent(out),optional :: found
+    character(kind=CK,len=*),dimension(:),intent(in),optional :: default
+    integer(IK),dimension(:),intent(in),optional :: default_ilen !! the actual
+                                                                 !! length of `default`
 
-    call json%get(me,to_unicode(path),vec,ilen,found)
+    call json%get(me,to_unicode(path),vec,ilen,found,default,default_ilen)
 
     end subroutine wrap_json_get_alloc_string_vec_by_path
 !*****************************************************************************************

--- a/src/tests/jf_test_46.F90
+++ b/src/tests/jf_test_46.F90
@@ -31,14 +31,16 @@ contains
     integer(IK) :: ival
     real(RK) :: rval
     real :: r32val
+    real,dimension(:),allocatable :: r32vec
     logical(LK) :: lval
     character(kind=CK,len=:),allocatable :: cval
     character(kind=CK,len=1),dimension(:),allocatable :: cvec
     character(kind=CK,len=:),dimension(:),allocatable :: cvec2
     integer(IK),dimension(:),allocatable :: ilen
 
-    character(kind=CK,len=1),dimension(1) :: cvec_default = [CK_'1']
-    integer(IK),dimension(1) :: ilen_default = [1]
+    character(kind=CK,len=1),dimension(1),parameter :: cvec_default = [CK_'1']
+    integer(IK),dimension(1),parameter :: ilen_default = [1]
+    real,dimension(1),parameter :: r32vec_default = [99.0]
 
     write(error_unit,'(A)') ''
     write(error_unit,'(A)') '================================='
@@ -65,7 +67,13 @@ contains
 
     call json%get(p, CK_'not_there', r32val, found, default=99.0)  ! real32
     if (json%failed() .or. found .or. r32val-99.0>0.0) then
-        write(error_unit,'(A)') 'Error using json_get_real_by_path default'
+        write(error_unit,'(A)') 'Error using json_get_real32_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json%get(p, CK_'not_there', r32vec, found, default=r32vec_default)  ! real32 vec
+    if (json%failed() .or. found .or. any(r32vec-r32vec_default>.0)) then
+        write(error_unit,'(A)') 'Error using json_get_real32_by_path default'
         error_cnt = error_cnt + 1
     end if
 
@@ -88,17 +96,17 @@ contains
     end if
 
     call json%get(p, CK_'not_there', cvec, found, default=cvec_default)
-    if (json%failed() .or. found .or. all(cvec /= cvec_default)) then
+    if (json%failed() .or. found .or. any(cvec /= cvec_default)) then
         write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
     call json%get(p, CK_'not_there', cvec2, ilen, found, default=cvec_default)
-    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+    if (json%failed() .or. found .or. any(cvec2 /= cvec_default) .or. any(ilen/=1_IK)) then
         write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
     call json%get(p, CK_'not_there', cvec2, ilen, found, default=cvec_default, default_ilen=ilen_default)
-    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+    if (json%failed() .or. found .or. any(cvec2 /= cvec_default) .or. any(ilen/=1_IK)) then
         write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
@@ -129,17 +137,17 @@ contains
     end if
 
     call json%get(p, 'not_there', cvec, found, default=[CK_'1'])
-    if (json%failed() .or. found .or. all(cvec /= [CK_'1'])) then
+    if (json%failed() .or. found .or. any(cvec /= [CK_'1'])) then
         write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
     call json%get(p, 'not_there', cvec2, ilen, found, default=cvec_default)
-    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+    if (json%failed() .or. found .or. any(cvec2 /= cvec_default) .or. any(ilen/=1_IK)) then
         write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
     call json%get(p, 'not_there', cvec2, ilen, found, default=cvec_default, default_ilen=ilen_default)
-    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+    if (json%failed() .or. found .or. any(cvec2 /= cvec_default) .or. any(ilen/=1_IK)) then
         write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
@@ -186,17 +194,17 @@ contains
     end if
 
     call json_f%get(CK_'not_there', cvec, found, default=cvec_default)
-    if (json%failed() .or. found .or. all(cvec /= cvec_default)) then
+    if (json%failed() .or. found .or. any(cvec /= cvec_default)) then
         write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
     call json_f%get(CK_'not_there', cvec2, ilen, found, default=cvec_default)
-    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+    if (json%failed() .or. found .or. any(cvec2 /= cvec_default) .or. any(ilen/=1_IK)) then
         write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
     call json_f%get(CK_'not_there', cvec2, ilen, found, default=cvec_default, default_ilen=ilen_default)
-    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+    if (json%failed() .or. found .or. any(cvec2 /= cvec_default) .or. any(ilen/=1_IK)) then
         write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
@@ -227,17 +235,17 @@ contains
     end if
 
     call json_f%get('not_there', cvec, found, default=cvec_default)
-    if (json%failed() .or. found .or. all(cvec /= cvec_default)) then
+    if (json%failed() .or. found .or. any(cvec /= cvec_default)) then
         write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
     call json_f%get('not_there', cvec2, ilen, found, default=cvec_default)
-    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+    if (json%failed() .or. found .or. any(cvec2 /= cvec_default) .or. any(ilen/=1_IK)) then
         write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
     call json_f%get('not_there', cvec2, ilen, found, default=cvec_default, default_ilen=ilen_default)
-    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+    if (json%failed() .or. found .or. any(cvec2 /= cvec_default) .or. any(ilen/=1_IK)) then
         write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if

--- a/src/tests/jf_test_46.F90
+++ b/src/tests/jf_test_46.F90
@@ -1,0 +1,214 @@
+!*****************************************************************************************
+!>
+! Module for the 46th unit test
+
+module jf_test_46_mod
+
+    use json_module, CK => json_CK, IK => json_IK, RK => json_RK, LK => json_LK
+    use, intrinsic :: iso_fortran_env , only: error_unit, output_unit
+
+    implicit none
+
+    private
+    public :: test_46
+
+contains
+
+    subroutine test_46(error_cnt)
+
+    !! testing of default optional argument
+
+    implicit none
+
+    integer,intent(out) :: error_cnt !! error counter
+
+    character(kind=CK,len=*),parameter :: str = CK_'{"x": 1}'
+
+    type(json_core) :: json
+    type(json_file) :: json_f
+    type(json_value),pointer :: p
+    logical(LK) :: found
+    integer(IK) :: ival
+    real(RK) :: rval
+    logical(LK) :: lval
+    character(kind=CK,len=:),allocatable :: cval
+    character(kind=CK,len=1),dimension(:),allocatable :: cvec
+
+    character(kind=CK,len=1),dimension(1) :: cvec_default = [CK_'1']
+
+    write(error_unit,'(A)') ''
+    write(error_unit,'(A)') '================================='
+    write(error_unit,'(A)') '   TEST 46'
+    write(error_unit,'(A)') '================================='
+    write(error_unit,'(A)') ''
+
+    ! note: don't have one for json_get_alloc_string_vec_by_path
+
+    error_cnt = 0
+
+    !---------------------------------
+    ! first core routines:
+    !---------------------------------
+
+    call json%deserialize(p,str)
+
+    ! unicode:
+    call json%get(p, CK_'not_there', ival, found, default=99_IK)
+    if (json%failed() .or. found .or. ival /= 99_IK) then
+        write(error_unit,'(A)') 'Error using json_get_integer_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json%get(p, CK_'not_there', rval, found, default=99.0_RK)
+    if (json%failed() .or. found .or. rval-99.0_RK>0.0_RK) then
+        write(error_unit,'(A)') 'Error using json_get_real_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json%get(p, CK_'not_there', lval, found, default=.true.)
+    if (json%failed() .or. found .or. lval .neqv. .true.) then
+        write(error_unit,'(A)') 'Error using json_get_logical_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json%get(p, CK_'not_there', cval, found, default=CK_'default')
+    if (json%failed() .or. found .or. cval /= CK_'default') then
+        write(error_unit,'(A)') 'Error using json_get_string_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json%get(p, CK_'not_there', cvec, found, default=cvec_default)
+    if (json%failed() .or. found .or. all(cvec /= cvec_default)) then
+        write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    ! default:
+    call json%get(p, 'not_there', ival, found, default=99_IK)
+    if (json%failed() .or. found .or. ival /= 99_IK) then
+        write(error_unit,'(A)') 'Error using json_get_integer_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json%get(p, 'not_there', rval, found, default=99.0_RK)
+    if (json%failed() .or. found .or. rval-99.0_RK>0.0_RK) then
+        write(error_unit,'(A)') 'Error using json_get_real_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json%get(p, 'not_there', lval, found, default=.true.)
+    if (json%failed() .or. found .or. lval .neqv. .true.) then
+        write(error_unit,'(A)') 'Error using json_get_logical_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json%get(p, 'not_there', cval, found, default=CK_'default')
+    if (json%failed() .or. found .or. cval /= CK_'default') then
+        write(error_unit,'(A)') 'Error using json_get_string_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json%get(p, 'not_there', cvec, found, default=[CK_'1'])
+    if (json%failed() .or. found .or. all(cvec /= [CK_'1'])) then
+        write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json%destroy(p)
+
+    !---------------------------------
+    ! now, json_file routines:
+    !---------------------------------
+
+    json_f = json_file(str)
+
+    ! unicode:
+    call json_f%get(CK_'not_there', ival, found, default=99_IK)
+    if (json%failed() .or. found .or. ival /= 99_IK) then
+        write(error_unit,'(A)') 'Error using json_get_integer_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json_f%get(CK_'not_there', rval, found, default=99.0_RK)
+    if (json%failed() .or. found .or. rval-99.0_RK>0.0_RK) then
+        write(error_unit,'(A)') 'Error using json_get_real_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json_f%get(CK_'not_there', lval, found, default=.true.)
+    if (json%failed() .or. found .or. lval .neqv. .true.) then
+        write(error_unit,'(A)') 'Error using json_get_logical_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json_f%get(CK_'not_there', cval, found, default=CK_'default')
+    if (json%failed() .or. found .or. cval /= CK_'default') then
+        write(error_unit,'(A)') 'Error using json_get_string_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json_f%get(CK_'not_there', cvec, found, default=cvec_default)
+    if (json%failed() .or. found .or. all(cvec /= cvec_default)) then
+        write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    ! default:
+    call json_f%get('not_there', ival, found, default=99_IK)
+    if (json%failed() .or. found .or. ival /= 99_IK) then
+        write(error_unit,'(A)') 'Error using json_get_integer_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json_f%get('not_there', rval, found, default=99.0_RK)
+    if (json%failed() .or. found .or. rval-99.0_RK>0.0_RK) then
+        write(error_unit,'(A)') 'Error using json_get_real_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json_f%get('not_there', lval, found, default=.true.)
+    if (json%failed() .or. found .or. lval .neqv. .true.) then
+        write(error_unit,'(A)') 'Error using json_get_logical_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json_f%get('not_there', cval, found, default=CK_'default')
+    if (json%failed() .or. found .or. cval /= CK_'default') then
+        write(error_unit,'(A)') 'Error using json_get_string_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json_f%get('not_there', cvec, found, default=cvec_default)
+    if (json%failed() .or. found .or. all(cvec /= cvec_default)) then
+        write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    if (error_cnt==0) then
+        write(error_unit,'(A)') 'Success!'
+    else
+        write(error_unit,'(A)') 'Failed!'
+    end if
+    write(error_unit,'(A)') ''
+
+    end subroutine test_46
+
+end module jf_test_46_mod
+!*****************************************************************************************
+
+#ifndef INTEGRATED_TESTS
+!*****************************************************************************************
+program jf_test_46
+
+    !! 46th unit test.
+
+    use jf_test_46_mod , only: test_46
+    implicit none
+    integer :: n_errors
+    n_errors = 0
+    call test_46(n_errors)
+    if (n_errors /= 0) stop 1
+
+end program jf_test_46
+!*****************************************************************************************
+#endif

--- a/src/tests/jf_test_46.F90
+++ b/src/tests/jf_test_46.F90
@@ -72,7 +72,7 @@ contains
     end if
 
     call json%get(p, CK_'not_there', r32vec, found, default=r32vec_default)  ! real32 vec
-    if (json%failed() .or. found .or. any(r32vec-r32vec_default>.0)) then
+    if (json%failed() .or. found .or. any(r32vec-r32vec_default>0.0)) then
         write(error_unit,'(A)') 'Error using json_get_real32_by_path default'
         error_cnt = error_cnt + 1
     end if

--- a/src/tests/jf_test_46.F90
+++ b/src/tests/jf_test_46.F90
@@ -243,7 +243,8 @@ contains
     end if
 
     ! now, we try them when an exception is active:
-    call json_f%get(CK_'not_there', ival) ! this will raise an exception
+    call json_f%destroy()
+    json_f = json_file(CK_'{"x": 1.0e.2.1}') ! this will raise an exception
     call json_f%get(CK_'not_there', rval, found, default=99.0_RK)
     call json_f%get(CK_'not_there', cvec, found, default=[CK_'1'])
     call json_f%get(CK_'not_there', cvec2, ilen, found, default=cvec_default)

--- a/src/tests/jf_test_46.F90
+++ b/src/tests/jf_test_46.F90
@@ -30,6 +30,7 @@ contains
     logical(LK) :: found
     integer(IK) :: ival
     real(RK) :: rval
+    real :: r32val
     logical(LK) :: lval
     character(kind=CK,len=:),allocatable :: cval
     character(kind=CK,len=1),dimension(:),allocatable :: cvec
@@ -56,6 +57,12 @@ contains
     call json%get(p, CK_'not_there', ival, found, default=99_IK)
     if (json%failed() .or. found .or. ival /= 99_IK) then
         write(error_unit,'(A)') 'Error using json_get_integer_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+
+    call json%get(p, CK_'not_there', r32val, found, default=99.0)  ! real32
+    if (json%failed() .or. found .or. r32val-99.0>0.0) then
+        write(error_unit,'(A)') 'Error using json_get_real_by_path default'
         error_cnt = error_cnt + 1
     end if
 

--- a/src/tests/jf_test_46.F90
+++ b/src/tests/jf_test_46.F90
@@ -144,7 +144,15 @@ contains
         error_cnt = error_cnt + 1
     end if
 
+    ! now, we try them when an exception is active:
+    call json%get(p, CK_'not_there', ival) ! this will raise an exception
+    call json%get(p, CK_'not_there', rval, found, default=99.0_RK)
+    call json%get(p, CK_'not_there', cvec, found, default=[CK_'1'])
+    call json%get(p, CK_'not_there', cvec2, ilen, found, default=cvec_default)
+    call json%get(p, CK_'not_there', cvec2, ilen, found, default=cvec_default, default_ilen=ilen_default)
+
     call json%destroy(p)
+    call json%destroy()
 
     !---------------------------------
     ! now, json_file routines:
@@ -233,6 +241,13 @@ contains
         write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
+
+    ! now, we try them when an exception is active:
+    call json_f%get(CK_'not_there', ival) ! this will raise an exception
+    call json_f%get(CK_'not_there', rval, found, default=99.0_RK)
+    call json_f%get(CK_'not_there', cvec, found, default=[CK_'1'])
+    call json_f%get(CK_'not_there', cvec2, ilen, found, default=cvec_default)
+    call json_f%get(CK_'not_there', cvec2, ilen, found, default=cvec_default, default_ilen=ilen_default)
 
     if (error_cnt==0) then
         write(error_unit,'(A)') 'Success!'

--- a/src/tests/jf_test_46.F90
+++ b/src/tests/jf_test_46.F90
@@ -34,8 +34,11 @@ contains
     logical(LK) :: lval
     character(kind=CK,len=:),allocatable :: cval
     character(kind=CK,len=1),dimension(:),allocatable :: cvec
+    character(kind=CK,len=:),dimension(:),allocatable :: cvec2
+    integer(IK),dimension(:),allocatable :: ilen
 
     character(kind=CK,len=1),dimension(1) :: cvec_default = [CK_'1']
+    integer(IK),dimension(1) :: ilen_default = [1]
 
     write(error_unit,'(A)') ''
     write(error_unit,'(A)') '================================='
@@ -89,6 +92,16 @@ contains
         write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
+    call json%get(p, CK_'not_there', cvec2, ilen, found, default=cvec_default)
+    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+        write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+    call json%get(p, CK_'not_there', cvec2, ilen, found, default=cvec_default, default_ilen=ilen_default)
+    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+        write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
 
     ! default:
     call json%get(p, 'not_there', ival, found, default=99_IK)
@@ -118,6 +131,16 @@ contains
     call json%get(p, 'not_there', cvec, found, default=[CK_'1'])
     if (json%failed() .or. found .or. all(cvec /= [CK_'1'])) then
         write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+    call json%get(p, 'not_there', cvec2, ilen, found, default=cvec_default)
+    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+        write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+    call json%get(p, 'not_there', cvec2, ilen, found, default=cvec_default, default_ilen=ilen_default)
+    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+        write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
 
@@ -159,6 +182,16 @@ contains
         write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
+    call json_f%get(CK_'not_there', cvec2, ilen, found, default=cvec_default)
+    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+        write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+    call json_f%get(CK_'not_there', cvec2, ilen, found, default=cvec_default, default_ilen=ilen_default)
+    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+        write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
 
     ! default:
     call json_f%get('not_there', ival, found, default=99_IK)
@@ -188,6 +221,16 @@ contains
     call json_f%get('not_there', cvec, found, default=cvec_default)
     if (json%failed() .or. found .or. all(cvec /= cvec_default)) then
         write(error_unit,'(A)') 'Error using json_get_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+    call json_f%get('not_there', cvec2, ilen, found, default=cvec_default)
+    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+        write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
+        error_cnt = error_cnt + 1
+    end if
+    call json_f%get('not_there', cvec2, ilen, found, default=cvec_default, default_ilen=ilen_default)
+    if (json%failed() .or. found .or. all(cvec2 /= cvec_default) .or. all(ilen/=1_IK)) then
+        write(error_unit,'(A)') 'Error using json_get_alloc_string_vec_by_path default'
         error_cnt = error_cnt + 1
     end if
 

--- a/visual_studio/jsonfortrantest/jsonfortrantest.f90
+++ b/visual_studio/jsonfortrantest/jsonfortrantest.f90
@@ -100,6 +100,8 @@
     call test_42(n_errors); if (n_errors /= 0) stop 1
     call test_43(n_errors); if (n_errors /= 0) stop 1
     call test_44(n_errors); if (n_errors /= 0) stop 1
+    call test_45(n_errors); if (n_errors /= 0) stop 1
+    call test_46(n_errors); if (n_errors /= 0) stop 1
 
     end program jsonfortrantest
 !*****************************************************************************************

--- a/visual_studio/jsonfortrantest/jsonfortrantest.vfproj
+++ b/visual_studio/jsonfortrantest/jsonfortrantest.vfproj
@@ -90,5 +90,7 @@
 		<File RelativePath="..\..\src\tests\jf_test_42.F90"/>
 		<File RelativePath="..\..\src\tests\jf_test_43.F90"/>
 		<File RelativePath="..\..\src\tests\jf_test_44.F90"/>
+		<File RelativePath="..\..\src\tests\jf_test_45.F90"/>
+		<File RelativePath="..\..\src\tests\jf_test_46.F90"/>
 		<File RelativePath=".\jsonfortrantest.f90"/></Filter></Files>
 	<Globals/></VisualStudioProject>


### PR DESCRIPTION
Fixes #208. Adds a `default` optional argument to the `json_get_*_by_path` routines. To make it easier to set values that aren't found in file, with only one line of code.

This also consolidates some duplicated code into include files.