### PR TITLE
Minor changes for nvfortran

### DIFF
--- a/src/json_parameters.F90
+++ b/src/json_parameters.F90
@@ -57,14 +57,14 @@
     character(kind=CK,len=*),parameter :: dot             = CK_'.'  !! path separator for [[json_get_by_path_default]]
     character(kind=CK,len=*),parameter :: tilde           = CK_'~'  !! RFC 6901 escape character
     character(kind=CK,len=*),parameter :: single_quote    = CK_"'"  !! for JSONPath bracket-notation
-    character(kind=CK,len=*),parameter :: slash           = CK_'/'  !! JSON special character
-    character(kind=CK,len=*),parameter :: backslash       = CK_'\'  !! JSON special character
     character(kind=CK,len=*),parameter :: quotation_mark  = CK_'"'  !! JSON special character
     character(kind=CK,len=*),parameter :: bspace          = achar(8,  kind=CK) !! JSON special character
     character(kind=CK,len=*),parameter :: horizontal_tab  = achar(9,  kind=CK) !! JSON special character
     character(kind=CK,len=*),parameter :: newline         = achar(10, kind=CK) !! JSON special character
     character(kind=CK,len=*),parameter :: formfeed        = achar(12, kind=CK) !! JSON special character
     character(kind=CK,len=*),parameter :: carriage_return = achar(13, kind=CK) !! JSON special character
+    character(kind=CK,len=*),parameter :: slash           = achar(47, kind=CK) !! JSON special character
+    character(kind=CK,len=*),parameter :: backslash       = achar(92, kind=CK) !! JSON special character
 
     !> default real number format statement (for writing real values to strings and files).
     !  Note that this can be overridden by calling [[json_initialize]].


### PR DESCRIPTION
Hello,

When compiling JSON-Fortran with the [nvfortran](https://docs.nvidia.com/hpc-sdk/index.html) compiler, I ran into the following errors:

1.
```
NVFORTRAN-S-0026-Unmatched quote (/home/yu/opt/json-fortran/src/json_parameters.F90: 61)
```
Change: Partly reverted commit 90fee68f02.

2.
```
NVFORTRAN-S-0188-Argument number 2 to add_to_path: type mismatch (/home/yu/opt/json-fortran/src/json_value_module.F90: 7875)
```
Change: Removed an optional argument that is not used anyway.

With these changes, JSON-Fortran compiles with nvfortran 21.5 and 21.7.

Feel free to close if support for nvfortran is not of interest.

Thanks!