### PR TITLE
Export include directories with target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,11 +179,11 @@ endif()
 
 target_include_directories(${LIB_NAME}
   PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+  $<BUILD_INTERFACE:${MODULE_DIR}>
   $<INSTALL_INTERFACE:${INSTALL_MOD_DIR}>)
 target_include_directories(${LIB_NAME}-static
   PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+  $<BUILD_INTERFACE:${MODULE_DIR}>
   $<INSTALL_INTERFACE:${INSTALL_MOD_DIR}>)
 set_target_properties ( ${LIB_NAME}-static
   PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,14 @@ if(JSON_FORTRAN_USE_OpenCoarrays)
     PRIVATE OpenCoarrays::caf_mpi_static)
 endif()
 
+target_include_directories(${LIB_NAME}
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:${INSTALL_MOD_DIR}>)
+target_include_directories(${LIB_NAME}-static
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:${INSTALL_MOD_DIR}>)
 set_target_properties ( ${LIB_NAME}-static
   PROPERTIES
   OUTPUT_NAME ${LIB_NAME}
@@ -438,7 +446,9 @@ add_custom_target ( uninstall
 #-----------------------------------------------------
 # Publicize installed location to other CMake projects
 #-----------------------------------------------------
-install ( EXPORT ${PACKAGE_NAME}-targets DESTINATION "${EXPORT_INSTALL_DIR}" )
+install ( EXPORT ${PACKAGE_NAME}-targets
+  NAMESPACE ${PACKAGE_NAME}::
+  DESTINATION "${EXPORT_INSTALL_DIR}" )
 
 include ( CMakePackageConfigHelpers ) # Standard CMake module
 write_basic_package_version_file( "${PROJECT_BINARY_DIR}/${PACKAGE_NAME}-config-version.cmake"

--- a/README.md
+++ b/README.md
@@ -122,15 +122,14 @@ enable_language ( Fortran )
 project ( jf_test NONE )
 
 find_package ( jsonfortran-${CMAKE_Fortran_COMPILER_ID} 8.2.5 REQUIRED )
-include_directories ( "${jsonfortran_INCLUDE_DIRS}" )
 
 file ( GLOB JF_TEST_SRCS "src/tests/jf_test_*.F90" )
 foreach ( UNIT_TEST ${JF_TEST_SRCS} )
   get_filename_component ( TEST ${UNIT_TEST} NAME_WE )
   add_executable ( ${TEST} ${UNIT_TEST} )
-  target_link_libraries ( ${TEST} jsonfortran-static )
+  target_link_libraries ( ${TEST} jsonfortran::jsonfortran-static )
   # or for linking against the dynamic/shared library:
-  # target_link_libraries ( ${TEST} jsonfortran ) # instead
+  # target_link_libraries ( ${TEST} jsonfortran::jsonfortran ) # instead
 endforeach()
 ```
 


### PR DESCRIPTION
- add `BUILD_INTERFACE` for finding modules in build directory
- add `INSTALL_INTERFACE` to associate include directory with target
- add namespace to exported target
  - `jsonfortran::jsonfortran` target instead of `jsonfortran`
  - `jsonfortran::jsonfortran-static` target instead of `jsonfortran-static`

Closes #503 