### PR TITLE
Fix readme heading so "top" links work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-![JSON-Fortran](/media/json-fortran-logo-2.png)
-============
+<h1 id="json-fortran"><img alt="JSON-Fortran" src="/media/json-fortran-logo-2.png" title="JSON-Fortran logo"></h1>
 
 JSON-Fortran: A Modern Fortran JSON API
 


### PR DESCRIPTION
This creates a `#json-fortran` target, allowing the "top" links and the ToC link in the readme to work properly.