### PR TITLE
adding aliases for libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,11 @@ set ( LIB_NAME ${PROJECT_NAME} )
 add_library ( ${LIB_NAME}        SHARED ${JF_LIB_SRCS} )
 add_library ( ${LIB_NAME}-static STATIC ${JF_LIB_SRCS} )
 
+# add an alias so that including json-fortran is agnostic
+# of find_package or being directly compiled through add_subdirectory
+add_library ( ${PACKAGE_NAME}::${LIB_NAME}        ALIAS ${LIB_NAME} )
+add_library ( ${PACKAGE_NAME}::${LIB_NAME}-static ALIAS ${LIB_NAME}-static )
+
 if(JSON_FORTRAN_USE_OpenCoarrays)
   target_link_libraries(${LIB_NAME}
     PRIVATE OpenCoarrays::caf_mpi_static)


### PR DESCRIPTION
Adds a [library alias](https://cmake.org/cmake/help/latest/command/add_library.html#alias-libraries) so that json fortran can be included with find_package, fetch_content, and add_subdirectory easily.