### PR TITLE
Fixes compilation with Ninja and IntelLLVM when using OneAPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,11 +236,11 @@ set_target_properties ( ${LIB_NAME}
 # Build the documentation with FORD
 #-------------------------------------
 if (JSONFORTRAN_ENABLE_DOC_GENERATION)
-  set(SKIP_DOC_GEN FALSE)
+  set(SKIP_DOC_GEN FALSE CACHE BOOL "Disable building the API documentation with FORD")
+else ()
+  set(SKIP_DOC_GEN TRUE CACHE BOOL "Disable building the API documentation with FORD" )
 endif ()
 
-set ( SKIP_DOC_GEN FALSE CACHE BOOL
-  "Disable building the API documentation with FORD" )
 if ( NOT SKIP_DOC_GEN )
   find_program ( FORD ford )
   if ( FORD ) # Found
@@ -314,10 +314,10 @@ endif ()
 # Handle test related stuff
 #--------------------------
 if (JSONFORTRAN_ENABLE_TESTS)
-  set (ENABLE_TESTS FALSE)
+  set ( ENABLE_TESTS TRUE CACHE BOOL "Enable the JSON-Fortran tests." )
+else ()
+  set ( ENABLE_TESTS FALSE CACHE BOOL "Enable the JSON-Fortran tests." )
 endif ()
-set ( ENABLE_TESTS TRUE CACHE BOOL
-  "Enable the JSON-Fortran tests." )
 
 #---------------------------------------------------------------------
 # Add some tests to ensure that the software is performing as expected

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,11 @@
 # this software. The contributing author, Izaak Beekman, retains all
 # rights permitted by the terms of the JSON-Fortran license.
 
-cmake_minimum_required ( VERSION 2.8.8 FATAL_ERROR )
+cmake_minimum_required ( VERSION 3.18 FATAL_ERROR )
+
+option (JSONFORTRAN_ENABLE_DOC_GENERATION "Enable doc generation" OFF)
+option (JSONFORTRAN_ENABLE_TESTS "Enable tests" OFF)
+option (JSONFORTRAN_STATIC_LIBRARY_ONLY "Generate only static library" ON)
 
 # Use MSVS folders to organize projects on windows
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -174,8 +178,12 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL IntelLLVM)
     add_library ( ${LIB_NAME}        SHARED $<TARGET_OBJECTS:${LIB_NAME}-obj> )
     add_library ( ${LIB_NAME}-static STATIC $<TARGET_OBJECTS:${LIB_NAME}-obj> )
 else()
-    add_library ( ${LIB_NAME}        SHARED ${JF_LIB_SRCS} )
+  if (JSONFORTRAN_STATIC_LIBRARY_ONLY)
+    add_library ( ${LIB_NAME}        STATIC ${JF_LIB_SRCS} )
     add_library ( ${LIB_NAME}-static STATIC ${JF_LIB_SRCS} )
+  else()
+    add_library ( ${LIB_NAME}        SHARED ${JF_LIB_SRCS} )
+  endif()
 endif()
 
 if(JSON_FORTRAN_USE_OpenCoarrays)
@@ -227,6 +235,10 @@ set_target_properties ( ${LIB_NAME}
 #-------------------------------------
 # Build the documentation with FORD
 #-------------------------------------
+if (JSONFORTRAN_ENABLE_DOC_GENERATION)
+  set(SKIP_DOC_GEN FALSE)
+endif ()
+
 set ( SKIP_DOC_GEN FALSE CACHE BOOL
   "Disable building the API documentation with FORD" )
 if ( NOT SKIP_DOC_GEN )
@@ -301,6 +313,9 @@ endif ()
 #--------------------------
 # Handle test related stuff
 #--------------------------
+if (JSONFORTRAN_ENABLE_TESTS)
+  set (ENABLE_TESTS FALSE)
+endif ()
 set ( ENABLE_TESTS TRUE CACHE BOOL
   "Enable the JSON-Fortran tests." )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,8 +167,16 @@ endif ()
 #---------------------------------------------
 
 set ( LIB_NAME ${PROJECT_NAME} )
-add_library ( ${LIB_NAME}        SHARED ${JF_LIB_SRCS} )
-add_library ( ${LIB_NAME}-static STATIC ${JF_LIB_SRCS} )
+if(CMAKE_Fortran_COMPILER_ID STREQUAL IntelLLVM)
+    add_library ( ${LIB_NAME}-obj    OBJECT ${JF_LIB_SRCS} )
+    set_property(TARGET ${LIB_NAME}-obj PROPERTY POSITION_INDEPENDENT_CODE 1)
+
+    add_library ( ${LIB_NAME}        SHARED $<TARGET_OBJECTS:${LIB_NAME}-obj> )
+    add_library ( ${LIB_NAME}-static STATIC $<TARGET_OBJECTS:${LIB_NAME}-obj> )
+else()
+    add_library ( ${LIB_NAME}        SHARED ${JF_LIB_SRCS} )
+    add_library ( ${LIB_NAME}-static STATIC ${JF_LIB_SRCS} )
+endif()
 
 if(JSON_FORTRAN_USE_OpenCoarrays)
   target_link_libraries(${LIB_NAME}
@@ -185,15 +193,26 @@ target_include_directories(${LIB_NAME}-static
   PUBLIC
   $<BUILD_INTERFACE:${MODULE_DIR}>
   $<INSTALL_INTERFACE:${INSTALL_MOD_DIR}>)
-set_target_properties ( ${LIB_NAME}-static
-  PROPERTIES
-  OUTPUT_NAME ${LIB_NAME}
-  if(NOT MSVC_IDE)
-  PREFIX lib
-  endif()
-  VERSION ${VERSION}
-  ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
-  Fortran_MODULE_DIRECTORY ${MODULE_DIR} )
+if(CMAKE_Fortran_COMPILER_ID STREQUAL IntelLLVM)
+    set_target_properties ( ${LIB_NAME}-static
+      PROPERTIES
+      if(NOT MSVC_IDE)
+      PREFIX lib
+      endif()
+      VERSION ${VERSION}
+      ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+      Fortran_MODULE_DIRECTORY ${MODULE_DIR} )
+else()
+    set_target_properties ( ${LIB_NAME}-static
+      PROPERTIES
+      OUTPUT_NAME ${LIB_NAME}
+      if(NOT MSVC_IDE)
+      PREFIX lib
+      endif()
+      VERSION ${VERSION}
+      ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+      Fortran_MODULE_DIRECTORY ${MODULE_DIR} )
+endif()
 set_target_properties ( ${LIB_NAME}
   PROPERTIES
   OUTPUT_NAME ${LIB_NAME}


### PR DESCRIPTION
I have found some issues trying to compile with the recent Intel One API + Visual Studio 2022. Basically I got this error.

```
1> [CMake]   failed with:
1> [CMake] 
1> [CMake]    ninja: error: build.ninja:280: multiple rules generate jsonfortran.lib
```

I have implemented some changes in CMakeLists.txt to fix it by considering the case of IntelLLVM which is the compiler Id of the new compiler.

Best regards,
   Luis