### PR TITLE
Fixed an issue when IEEE floating-point rounding mode is IEEE_DOWN

### DIFF
--- a/src/json_string_utilities.F90
+++ b/src/json_string_utilities.F90
@@ -127,7 +127,7 @@
     ! Compute how many digits we need to read
     ndigits = 2*len_trim(str)
     if (ndigits/=0) then
-        ndigits_digits = floor(log10(real(ndigits)))+1
+        ndigits_digits = nint(log10(real(ndigits)))+1
         allocate(character(kind=CDK,len=ndigits_digits) :: digits)
         write(digits,'(I0)') ndigits !gfortran will have a runtime error with * edit descriptor here
         ! gfortran bug: '*' edit descriptor for ISO_10646 strings does bad stuff.


### PR DESCRIPTION
This solves an issue when IEEE floating-point rounding mode is manually set to `IEEE_DOWN`.
The original code in the `string_to_integer` subroutine
```fortran
        ndigits_digits = floor(log10(real(ndigits)))+1
```
erroneously returns 1 even when `ndigits` is 10 (while the correct value should be 2).

The following code is the minimum reproducible example of the problem.
The last `deserialize` will result in a crush.
```fortran
program jsontest
  use :: ieee_arithmetic
  use :: json_module

  type(json_file) :: file

  call ieee_set_rounding_mode(ieee_down) 

  call file%initialize()

  call file%deserialize('{"foo" : 100}')
  print *, "ok 1"
  call file%deserialize('{"foo" : 100, "bar" : 1000}')
  print *, "ok 2"
  call file%deserialize('{"foo" : 100, "bar" : 1000, "baz" : 10000}')
  print *, "ok 3"

  call file%destroy()

end program jsontest
```

I assume simply changing `floor` to `nint` should solve the issue without any side effects.