### PR TITLE
added an optional allow_trailing_comma flag

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -124,6 +124,7 @@ jobs:
         fpm test jf_test_48 --runner "valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1"
         fpm test jf_test_49 --runner "valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1"
         fpm test jf_test_50 --runner "valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1"
+        fpm test jf_test_51 --runner "valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1"
 
     - name: Compile_with_cmake
       # CMake build with unit tests, no documentation, with coverage analysis

--- a/fpm.toml
+++ b/fpm.toml
@@ -262,3 +262,8 @@ main       = "jf_test_49.F90"
 name       = "jf_test_50"
 source-dir = "src/tests"
 main       = "jf_test_50.F90"
+
+[[test]]
+name       = "jf_test_51"
+source-dir = "src/tests"
+main       = "jf_test_51.F90"

--- a/src/json_initialize_arguments.inc
+++ b/src/json_initialize_arguments.inc
@@ -112,3 +112,6 @@ logical(LK),intent(in),optional :: strict_integer_type_checking
   !!   value cannot be read.
   !!
   !! (default is true)
+logical(LK),intent(in),optional :: allow_trailing_comma
+  !! Allow a single trailing comma in arrays and objects.
+  !! (default is true)

--- a/src/json_initialize_dummy_arguments.inc
+++ b/src/json_initialize_dummy_arguments.inc
@@ -22,4 +22,5 @@ stop_on_error,&
 null_to_real_mode,&
 non_normal_mode,&
 use_quiet_nan, &
-strict_integer_type_checking &
+strict_integer_type_checking, &
+allow_trailing_comma &

--- a/src/tests/jf_test_51.F90
+++ b/src/tests/jf_test_51.F90
@@ -1,0 +1,92 @@
+!*****************************************************************************************
+!>
+!  Module for the 51th unit test. See Issue #569.
+
+module jf_test_51_mod
+
+    use json_module, wp => json_RK, IK => json_IK, LK => json_LK, CK => json_CK
+    use, intrinsic :: iso_fortran_env , only: error_unit, output_unit
+
+    implicit none
+
+    private
+    public :: test_51
+
+contains
+
+    subroutine test_51(error_cnt)
+
+    !! 51th unit test. see Issue #569
+
+    integer,intent(out) :: error_cnt
+
+    type(json_file) :: json
+
+    error_cnt = 0
+
+    write(error_unit,'(A)') ''
+    write(error_unit,'(A)') '================================='
+    write(error_unit,'(A)') '   EXAMPLE 51'
+    write(error_unit,'(A)') '================================='
+    write(error_unit,'(A)') ''
+
+    ! array cases:
+    call json%initialize(allow_trailing_comma = .false.)
+    call json%deserialize('{"a" : [1,2,3,]}')
+    if (.not. json%failed()) then
+        error_cnt = error_cnt + 1
+        write(error_unit,'(A)') 'read array with trailing comma'
+    else
+        ! it was supposed to fail
+        write(output_unit,'(A)') '1 success'
+    end if
+
+    call json%initialize(allow_trailing_comma = .true.)
+    call json%deserialize('{"a" : [1,2,3,]}')
+    if (json%failed()) then
+        error_cnt = error_cnt + 1
+        write(error_unit,'(A)') 'failed to read array with trailing comma'
+    else
+        write(output_unit,'(A)') '2 success'
+    end if
+
+    ! object cases:
+    call json%initialize(allow_trailing_comma = .false.)
+    call json%deserialize('{"a" : 1, "b" : 2, }')
+    if (.not. json%failed()) then
+        error_cnt = error_cnt + 1
+        write(error_unit,'(A)') 'read object with trailing comma'
+    else
+        ! it was supposed to fail
+        write(output_unit,'(A)') '3 success'
+    end if
+    call json%initialize(allow_trailing_comma = .true.)
+    call json%deserialize('{"a" : 1, "b" : 2, }')
+    if (json%failed()) then
+        error_cnt = error_cnt + 1
+        write(error_unit,'(A)') 'failed to read object with trailing comma'
+    else
+        write(output_unit,'(A)') '4 success'
+    end if
+
+    end subroutine test_51
+
+end module jf_test_51_mod
+!*****************************************************************************************
+
+!*****************************************************************************************
+#ifndef INTEGRATED_TESTS
+program jf_test_51
+
+    use jf_test_51_mod , only: test_51
+
+    implicit none
+    integer :: n_errors
+
+    call test_51(n_errors)
+    if (n_errors /= 0) stop 1
+
+end program jf_test_51
+#endif
+!*****************************************************************************************
+

--- a/visual_studio/jsonfortrantest/jsonfortrantest.vfproj
+++ b/visual_studio/jsonfortrantest/jsonfortrantest.vfproj
@@ -96,5 +96,6 @@
 		<File RelativePath="..\..\src\tests\jf_test_48.F90"/>
 		<File RelativePath="..\..\src\tests\jf_test_49.F90"/>
 		<File RelativePath="..\..\src\tests\jf_test_50.F90"/>
+		<File RelativePath="..\..\src\tests\jf_test_51.F90"/>
 		<File RelativePath=".\jsonfortrantest.f90"/></Filter></Files>
 	<Globals/></VisualStudioProject>


### PR DESCRIPTION
can be used to disallow extra trailing commas in arrays and objects (it is true by default and thus allowed) Fixes #569