### PR TITLE
Correct CMake namespace to match documentation.

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -1,5 +1,5 @@
 install ( EXPORT ${PACKAGE_NAME}-targets
-  NAMESPACE ${PACKAGE_NAME}::
+  NAMESPACE ${PROJECT_NAME}::
   DESTINATION "${EXPORT_INSTALL_DIR}" )
 
 include ( CMakePackageConfigHelpers ) # Standard CMake module


### PR DESCRIPTION
Correct the namespace added to the package in the CMake build-system installation. Instead of `jsonfortran-<compiler_id>` it is now simply jsonfortran. Fixes #579 