### PR TITLE
Fix UCS4 introspection source path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ set ( JF_LIB_SRCS  src/json_kinds.F90
                    src/json_file_module.F90
                    src/json_module.F90 )
 file ( GLOB JF_TEST_SRCS "test/jf_test_*.F90" )
-set ( JF_TEST_UCS4_SUPPORT_SRC "${PROJECT_SOURCE_DIR}/src/tests/introspection/test_iso_10646_support.f90")
+set ( JF_TEST_UCS4_SUPPORT_SRC "${PROJECT_SOURCE_DIR}/test/introspection/test_iso_10646_support.f90")
 
 #-----------------------------------------
 # Collect all the mod files into their own


### PR DESCRIPTION
The Unicode/UCS4 introspection source path in `CMakeLists.txt` points to `src/tests/...`, but the release tarball ships the file under `test/introspection/...`.

This breaks 9.3.0 source builds with `ENABLE_UNICODE=TRUE`.

Reference: https://github.com/Homebrew/homebrew-core/pull/276571